### PR TITLE
Allow valid permutations of molecules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "nodemon",
     "test": "jest --coverage",
     "start": "ts-node src/index.ts",
-    "build": "tsc",
+    "build": "yarn && tsc",
     "serve": "node dist/index.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
-    "inequality-grammar": "^1.2.2",
+    "inequality-grammar": "^1.3.2",
     "lodash": "^4.17.21"
   }
 }

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -317,7 +317,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         newResponse.sameCoefficient = newResponse.sameCoefficient && test.coeff === target.coeff;
         newResponse.sameBrackets = newResponse.sameBrackets && test.bracket === target.bracket;
-        newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && newResponse.sameBrackets;
+        newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && test.bracket === target.bracket;
 
         if (newResponse.bracketAtomCount) {
             for (const [key, value] of Object.entries(newResponse.bracketAtomCount)) {

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -57,7 +57,7 @@ export interface Ion extends ASTNode {
     type: 'ion';
     molecule: Molecule;
     charge: number;
-    chain?: Ion;
+    chain?: Ion | Molecule;
     molecules?: [Molecule, number][];
 }
 export function isIon(node: ASTNode): node is Ion {
@@ -162,8 +162,13 @@ function augmentNode<T extends ASTNode>(node: T): T {
 
                 // Recursively augmented
                 if (node.chain) {
-                    const augmentedChain: Ion = augmentNode(node.chain);
-                    molecules = augmentedChain.molecules ?? [];
+                    const augmentedChain = augmentNode(node.chain);
+
+                    if (isIon(augmentedChain)) {
+                        molecules = augmentedChain.molecules ?? [];
+                    } else {
+                        molecules = [[augmentedChain, 0]]
+                    }
                 }
 
                 const augmentedMolecule: Molecule = augmentNode(node.molecule)

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -34,6 +34,7 @@ export function isElement(node: ASTNode): node is Element {
 
 export interface Bracket extends ASTNode {
     type: 'bracket';
+    bracket: 'round' | 'square';
     compound: Compound;
     coeff: number;
 }
@@ -310,7 +311,8 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         const newResponse = checkNodesEqual(test.compound, target.compound, response);
 
         newResponse.sameCoefficient = newResponse.sameCoefficient && test.coeff === target.coeff;
-        newResponse.isEqual = newResponse.isEqual && test.coeff === target.coeff;
+        newResponse.sameBrackets = newResponse.sameBrackets && test.bracket === target.bracket;
+        newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && newResponse.sameBrackets;
 
         if (newResponse.bracketAtomCount) {
             for (const [key, value] of Object.entries(newResponse.bracketAtomCount)) {

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -26,6 +26,7 @@ export interface Element extends ASTNode {
     value: ChemicalSymbol;
     coeff: number;
     bracketed?: boolean;
+    compounded?: boolean;
 }
 export function isElement(node: ASTNode): node is Element {
     return node.type === 'element';
@@ -130,11 +131,15 @@ function augmentNode<T extends ASTNode>(node: T): T {
                 elements.push(augmentedHead)
 
                 for (let element of elements) {
+                    if (isElement(element)) {
+                        element.compounded = true;
+                    } 
+
                     if (node.bracketed)  {
                         if (isCompound(element) || isElement(element)) {
                             element.bracketed = true;
                         }
-                        else {
+                        else { // isBracket
                             // TODO: allow for nested brackets?
                             const errorNode = {
                                 type: "error",
@@ -278,7 +283,7 @@ function typesMatch(compound1: (Element | Bracket)[], compound2: (Element | Brac
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isElement(test) && isElement(target)) {
-        if (!response.allowPermutations) {
+        if (!response.allowPermutations || !test.compounded) {
             response.isEqual = response.isEqual &&
                 test.value === target.value &&
                 test.coeff === target.coeff;

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -259,7 +259,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
 }
 
-export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
+export function check(test: NuclearAST, target: NuclearAST, allowPermutations?: boolean): CheckerResponse {
     const response = {
         containsError: false,
         error: { message: "" },
@@ -271,6 +271,7 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
         isBalanced: true,
         isEqual: true,
         isNuclear: true,
+        allowPermutations: allowPermutations ?? false,
     }
     // Return shortcut response
     if (target.result.type === "error" || test.result.type === "error") {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -71,21 +71,21 @@ export interface NuclearAST {
     result: Result;
 }
 
-function flattenNode<T extends ASTNode>(node: T): T {
+function augmentNode<T extends ASTNode>(node: T): T {
     // The if statements signal to the type checker what we already know
     switch (node.type) {
         case "expr": {
             if(isExpression(node)) {
                 let terms: Term[] = [];
 
-                // Recursively flatten
+                // Recursively augmentten
                 if (node.rest) {
-                    const flatTerms: Expression | Term = flattenNode(node.rest);
+                    const augmentedTerms: Expression | Term = augmentNode(node.rest);
 
-                    if (isExpression(flatTerms)) {
-                        terms = flatTerms.terms ?? [];
+                    if (isExpression(augmentedTerms)) {
+                        terms = augmentedTerms.terms ?? [];
                     } else {
-                        terms = [flatTerms];
+                        terms = [augmentedTerms];
                     }
 
                     // Append the current term
@@ -102,23 +102,23 @@ function flattenNode<T extends ASTNode>(node: T): T {
         // Nodes with subtrees but no lists
         case "statement": {
             if (isStatement(node)) {
-                node.left = flattenNode(node.left);
-                node.right = flattenNode(node.right);
+                node.left = augmentNode(node.left);
+                node.right = augmentNode(node.right);
                 return node;
             }
         }
 
         // Leaves of the AST
-        case "term": // Term doesn't have subtrees that could be flattened
+        case "term": // Term doesn't have subtrees that could be augmented
         case "error":
         case "particle":
         case "isotope": return node;
     }
 }
 
-export function flatten(ast: NuclearAST): NuclearAST {
-    const flatResult: Result = flattenNode(ast.result);
-    return { result: flatResult };
+export function augment(ast: NuclearAST): NuclearAST {
+    const augmentResult: Result = augmentNode(ast.result);
+    return { result: augmentResult };
 }
 
 function isValidAtomicNumber(test: Particle | Isotope): boolean {
@@ -229,9 +229,9 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
             return listComparison(test.terms, target.terms, response, checkNodesEqual);
         } else {
-            console.error("[server] Encountered unflattened AST. Returning error");
+            console.error("[server] Encountered unaugmented AST. Returning error");
             response.containsError = true;
-            response.error = { message: "Received unflattened AST during checking process." };
+            response.error = { message: "Received unaugmented AST during checking process." };
             return response;
         }
     } else if (isStatement(test) && isStatement(target)) {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -268,6 +268,7 @@ export function check(test: NuclearAST, target: NuclearAST, allowPermutations?: 
         typeMismatch: false,
         sameState: true,
         sameCoefficient: true,
+        sameElements: true,
         isBalanced: true,
         isEqual: true,
         isNuclear: true,

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -21,9 +21,11 @@ export interface CheckerResponse {
     typeMismatch: boolean;
     sameState: boolean;
     sameCoefficient: boolean;
+    sameElements: boolean;
     allowPermutations: boolean;
     // properties dependent on type
     sameArrow?: boolean;
+    sameBrackets?: boolean;
     balancedCharge?: boolean;
     validAtomicNumber?: boolean;
     balancedAtom?: boolean;
@@ -31,7 +33,7 @@ export interface CheckerResponse {
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
-    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>; // TODO: allow for nested brackets?
+    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
     atomCount?: Record<ChemicalSymbol, number | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -1,7 +1,7 @@
 export const chemicalSymbol = ['H','He','Li','Be','B','C','N','O','F','Ne','Na','Mg','Al','Si','P','S','Cl','Ar','K','Ca','Sc','Ti','V','Cr','Mn','Fe','Co','Ni','Cu','Zn','Ga','Ge','As','Se','Br','Kr','Rb','Sr','Y','Zr','Nb','Mo','Tc','Ru','Rh','Pd','Ag','Cd','In','Sn','Sb','Te','I','Xe','Cs','Ba','La','Ce','Pr','Nd','Pm','Sm','Eu','Gd','Tb','Dy','Ho','Er','Tm','Yb','Lu','Hf','Ta','W','Re','Os','Ir','Pt','Au','Hg','Tl','Pb','Bi','Po','At','Rn','Fr','Ra','Ac','Th','Pa','U','Np','Pu','Am','Cm','Bk','Cf','Es','Fm','Md','No','Lr','Rf','Db','Sg','Bh','Hs','Mt','Ds','Rg','Cn','Nh','Fl','Mc','Lv','Ts','Og'] as const;
 export type ChemicalSymbol = typeof chemicalSymbol[number];
 
-export type ReturnType = 'term'|'expr'|'statement'|'error';
+export type ReturnType = 'term'|'expr'|'statement'|'error'|'unknown';
 
 type Aggregates = 'atomCount' | 'chargeCount' | 'nucleonCount';
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -21,6 +21,7 @@ export interface CheckerResponse {
     typeMismatch: boolean;
     sameState: boolean;
     sameCoefficient: boolean;
+    allowPermutations: boolean;
     // properties dependent on type
     sameArrow?: boolean;
     balancedCharge?: boolean;
@@ -28,6 +29,7 @@ export interface CheckerResponse {
     balancedAtom?: boolean;
     balancedMass?: boolean;
     // book keeping
+    checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
     bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
     atomCount?: Record<ChemicalSymbol, number | undefined>;

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -31,7 +31,7 @@ export interface CheckerResponse {
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
-    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
+    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>; // TODO: allow for nested brackets?
     atomCount?: Record<ChemicalSymbol, number | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -28,6 +28,8 @@ export interface CheckerResponse {
     balancedAtom?: boolean;
     balancedMass?: boolean;
     // book keeping
+    termAtomCount?: Record<ChemicalSymbol, number | undefined>;
+    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
     atomCount?: Record<ChemicalSymbol, number | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];
@@ -80,6 +82,8 @@ export function listComparison<T>(
 
             // Attach actual aggregate values
             returnResponse.chargeCount = aggregatesResponse.chargeCount;
+            returnResponse.bracketAtomCount = aggregatesResponse.bracketAtomCount;
+            returnResponse.termAtomCount = aggregatesResponse.termAtomCount;
             returnResponse.atomCount = aggregatesResponse.atomCount;
             returnResponse.nucleonCount = aggregatesResponse.nucleonCount;
 

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -26,7 +26,8 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: ChemAST = flatten(parseChemistryExpression(req.body.target)[0]);
     const test: ChemAST = flatten(parseChemistryExpression(req.body.test)[0]);
-    const result: CheckerResponse = check(test, target);
+    const allowPermutations: boolean = req.body.allowPermutations === "true" || false;
+    const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);
 

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -31,8 +31,12 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     res.status(201).send(result);
 
-    const str: string = JSON.stringify(result, null, 4);
-    console.log(`[server]: checker response ${str}`);
+    const resultStr: string = JSON.stringify(result, null, 4);
+
+    console.log(`[server]: question ID: ${req.body.questionID}`);
+    console.log(`[server]: target expression: ${req.body.target}`);
+    console.log(`[server]: test expression: ${req.body.test}`);
+    console.log(`[server]: checker response: ${resultStr}`);
 });
 
 router.post('/parse', parseValidationRules, (req: Request, res: Response) => {

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -26,7 +26,7 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: ChemAST = augment(parseChemistryExpression(req.body.target)[0]);
     const test: ChemAST = augment(parseChemistryExpression(req.body.test)[0]);
-    const allowPermutations: boolean = req.body.allowPermutations === "true" || true;
+    const allowPermutations: boolean = req.body.allowPermutations === "true";
     const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from "express";
 import { ValidationChain, body, validationResult } from "express-validator";
 import { parseChemistryExpression } from "inequality-grammar";
-import { check, flatten } from "../models/Chemistry";
+import { check, augment } from "../models/Chemistry";
 import { CheckerResponse } from "../models/common";
 
 const router = Router();
@@ -24,9 +24,9 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
         return res.status(400).json({ errors: errors.array() });
     }
 
-    const target: ChemAST = flatten(parseChemistryExpression(req.body.target)[0]);
-    const test: ChemAST = flatten(parseChemistryExpression(req.body.test)[0]);
-    const allowPermutations: boolean = req.body.allowPermutations === "true" || false;
+    const target: ChemAST = augment(parseChemistryExpression(req.body.target)[0]);
+    const test: ChemAST = augment(parseChemistryExpression(req.body.test)[0]);
+    const allowPermutations: boolean = req.body.allowPermutations === "true" || true;
     const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);
@@ -43,11 +43,11 @@ router.post('/parse', parseValidationRules, (req: Request, res: Response) => {
     }
 
     const parse: ChemAST = parseChemistryExpression(req.body.test)[0];
-    const flattened: ChemAST = flatten(parse);
+    const augmented: ChemAST = augment(parse);
 
-    res.status(201).send(flattened);
+    res.status(201).send(augmented);
 
-    const str: string = JSON.stringify(flattened, null, 4);
+    const str: string = JSON.stringify(augmented, null, 4);
     const request: string = req.body.description ? " '" + req.body.description + "'" : "";
     console.log(`[server]: Parsed request${request}`);
     console.log(`[server]: \n${str}`);

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -29,9 +29,13 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
     const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);
+    
+    const resultStr: string = JSON.stringify(result, null, 4);
 
-    const str: string = JSON.stringify(result, null, 4);
-    console.log(`[server]: checker response ${str}`);
+    console.log(`[server]: question ID: ${req.body.questionID}`);
+    console.log(`[server]: target expression: ${req.body.target}`);
+    console.log(`[server]: test expression: ${req.body.test}`);
+    console.log(`[server]: checker response: ${resultStr}`);
 });
 
 router.post('/parse', parseValidationRules, (req: Request, res: Response) => {

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -25,7 +25,8 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: NuclearAST = flatten(parseNuclearExpression(req.body.target)[0]);
     const test: NuclearAST = flatten(parseNuclearExpression(req.body.test)[0]);
-    const result: CheckerResponse = check(test, target);
+    const allowPermutations: boolean = req.body.allowPermutations === "true" || false;
+    const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);
 

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -1,7 +1,7 @@
 import { Request, Response, Router } from "express";
 import { ValidationChain, body, validationResult } from "express-validator";
 import { parseNuclearExpression } from "inequality-grammar";
-import { check, flatten } from "../models/Nuclear";
+import { check, augment } from "../models/Nuclear";
 import { CheckerResponse } from "../models/common";
 
 const router = Router();
@@ -23,9 +23,9 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
         return res.status(400).json({ errors: errors.array() });
     }
 
-    const target: NuclearAST = flatten(parseNuclearExpression(req.body.target)[0]);
-    const test: NuclearAST = flatten(parseNuclearExpression(req.body.test)[0]);
-    const allowPermutations: boolean = req.body.allowPermutations === "true" || false;
+    const target: NuclearAST = augment(parseNuclearExpression(req.body.target)[0]);
+    const test: NuclearAST = augment(parseNuclearExpression(req.body.test)[0]);
+    const allowPermutations: boolean = req.body.allowPermutations === "true";
     const result: CheckerResponse = check(test, target, allowPermutations);
 
     res.status(201).send(result);
@@ -42,10 +42,10 @@ router.post('/parse', parseValidationRules, (req: Request, res: Response) => {
     }
 
     const parse: NuclearAST = parseNuclearExpression(req.body.test)[0];
-    const flat: NuclearAST = flatten(parse);
-    res.status(201).send(flat);
+    const augmented: NuclearAST = augment(parse);
+    res.status(201).send(augmented);
 
-    const str: string = JSON.stringify(flat, null, 4);
+    const str: string = JSON.stringify(augmented, null, 4);
     const request: string = req.body.description ? " '" + req.body.description + "'" : "";
     console.log(`[server]: Parsed request${request}`);
     console.log(`[server]: \n${str}`);

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 const response: CheckerResponse = {
     containsError: false,
     error: { message: "" },
-    expectedType: "unknown",
+    expectedType: "statement",
     typeMismatch: false,
     sameState: true,
     sameCoefficient: true,
@@ -26,13 +26,14 @@ const response: CheckerResponse = {
     isEqual: true,
     isNuclear: false,
     atomCount: {} as Record<ChemicalSymbol, number | undefined>,
-    chargeCount: 0
+    chargeCount: 0,
+    receivedType: "statement"
 };
 // Alternative response object
 const newResponse: CheckerResponse = {
     containsError: false,
     error: { message: "" },
-    expectedType: "unknown",
+    expectedType: "statement",
     typeMismatch: false,
     sameState: false,
     sameCoefficient: false,
@@ -40,7 +41,8 @@ const newResponse: CheckerResponse = {
     isEqual: true,
     isNuclear: false,
     atomCount: {} as Record<ChemicalSymbol, number | undefined>,
-    chargeCount: 0
+    chargeCount: 0,
+    receivedType: "statement"
 };
 
 const trueResponse: CheckerResponse = structuredClone(newResponse);
@@ -640,7 +642,7 @@ describe("Check", () => {
             // Assert
             expect(response.error).toBeDefined();
             expect(response.error?.message).toBe("Sphinx of black quartz, judge my vow");
-            expect(response.expectedType).toBe("unknown");
+            expect(response.expectedType).toBe("statement");
         }
     );
     it("Returns type mismatch when appropriate",

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -1,4 +1,4 @@
-import { Bracket, Compound, Element, exportedForTesting, Ion, Term, Expression, Statement, ParseError, check, ChemAST, flatten } from "../../src/models/Chemistry";
+import { Bracket, Compound, Element, exportedForTesting, Ion, Term, Expression, Statement, ParseError, check, ChemAST, augment } from "../../src/models/Chemistry";
 import { ChemicalSymbol, CheckerResponse, listComparison } from "../../src/models/common";
 const { checkNodesEqual } = exportedForTesting;
 import { parseChemistryExpression } from "inequality-grammar";
@@ -13,7 +13,7 @@ afterEach(() => {
     console.error = original;
 })
 
-// TODO: Add flattening tests
+// TODO: Add augmenting tests
 
 // Generic response object
 const response: CheckerResponse = {
@@ -302,20 +302,20 @@ describe("checkNodesEqual Compounds", () => {
             expect(checkNodesEqual(elementMismatch, minimalCompound, structuredClone(response))).toEqual(elementResponse);
         }
     );
-    it("Returns an error if the AST is not flattened",
+    it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            // This is the same as compound just not flattened
-            const unflattenedCompound: Compound = {
+            // This is the same as compound just not augmented
+            const unaugmentedCompound: Compound = {
                 type: "compound",
                 head: { type: "element", value: "O", coeff: 2 },
                 tail: structuredClone(bracket)
             };
 
             // Assert
-            expect(checkNodesEqual(unflattenedCompound, compound, structuredClone(response)).containsError).toBeTruthy();
-            expect(checkNodesEqual(unflattenedCompound, compound, structuredClone(response)).error).toEqual(
-                { message: "Received unflattened AST during checking process." }
+            expect(checkNodesEqual(unaugmentedCompound, compound, structuredClone(response)).containsError).toBeTruthy();
+            expect(checkNodesEqual(unaugmentedCompound, compound, structuredClone(response)).error).toEqual(
+                { message: "Received unaugmented AST during checking process." }
             );
 
             expect(console.error).toHaveBeenCalled();
@@ -366,11 +366,11 @@ describe("CheckNodesEqual Ions", () => {
             expect(lengthIncorrect.isEqual).toBeFalsy();
         }
     );
-    it("Returns an error if the AST is not flattened",
+    it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            // This is the same as ion just not flattened
-            const unflattenedIon: Ion = {
+            // This is the same as ion just not augmented
+            const unaugmentedIon: Ion = {
                 type: "ion",
                 molecule: structuredClone(compound),
                 charge: -1,
@@ -382,9 +382,9 @@ describe("CheckNodesEqual Ions", () => {
             };
 
             // Assert
-            expect(checkNodesEqual(unflattenedIon, ion, structuredClone(response)).containsError).toBeTruthy();
-            expect(checkNodesEqual(unflattenedIon, ion, structuredClone(response)).error).toEqual(
-                { message: "Received unflattened AST during checking process." }
+            expect(checkNodesEqual(unaugmentedIon, ion, structuredClone(response)).containsError).toBeTruthy();
+            expect(checkNodesEqual(unaugmentedIon, ion, structuredClone(response)).error).toEqual(
+                { message: "Received unaugmented AST during checking process." }
             );
 
             expect(console.error).toHaveBeenCalled();
@@ -523,20 +523,20 @@ describe("CheckNodesEqual Expression", () => {
             ).toEqual(hydrateResponse);
         }
     );
-    it("Returns an error if the AST is not flattened",
+    it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            // This is the same as expression just unflattened
-            const unflattenedExpression: Expression = {
+            // This is the same as expression just unaugmented
+            const unaugmentedExpression: Expression = {
                 type: "expr",
                 term: structuredClone(hydrate),
                 rest: structuredClone(hydrate2)
             }
 
             // Assert
-            expect(checkNodesEqual(unflattenedExpression, expression, structuredClone(response)).containsError).toBeTruthy();
-            expect(checkNodesEqual(unflattenedExpression, expression, structuredClone(response)).error).toEqual(
-                { message: "Received unflattened AST during checking process." }
+            expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).containsError).toBeTruthy();
+            expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).error).toEqual(
+                { message: "Received unaugmented AST during checking process." }
             );
 
             expect(console.error).toHaveBeenCalled();
@@ -664,8 +664,8 @@ describe("Check", () => {
 
     it("Allows molecule permutations when allowPermutations set", () => { 
         // Act
-        const unchangedAST: ChemAST = flatten(parseChemistryExpression("C10H22")[0]);
-        const permutedAST: ChemAST = flatten(parseChemistryExpression("CH3(CH2)8CH3")[0]);
+        const unchangedAST: ChemAST = augment(parseChemistryExpression("C10H22")[0]);
+        const permutedAST: ChemAST = augment(parseChemistryExpression("CH3(CH2)8CH3")[0]);
 
         const permutedResponse: CheckerResponse = check(unchangedAST, permutedAST, true);
         const unpermutedResponse: CheckerResponse = check(unchangedAST, permutedAST, false);

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -26,7 +26,8 @@ const response: CheckerResponse = {
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
-    receivedType: "statement"
+    receivedType: "statement",
+    allowPermutations: false
 };
 // Alternative response object
 const newResponse: CheckerResponse = {
@@ -39,7 +40,8 @@ const newResponse: CheckerResponse = {
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
-    receivedType: "unknown"
+    receivedType: "unknown",
+    allowPermutations: false
 };
 
 const trueResponse: CheckerResponse = structuredClone(response);

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -19,13 +19,14 @@ afterEach(() => {
 const response: CheckerResponse = {
     containsError: false,
     error: { message: "" },
-    expectedType: "unknown",
+    expectedType: "statement",
     typeMismatch: false,
     sameState: true,
     sameCoefficient: true,
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
+    receivedType: "statement"
 };
 // Alternative response object
 const newResponse: CheckerResponse = {
@@ -38,6 +39,7 @@ const newResponse: CheckerResponse = {
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
+    receivedType: "unknown"
 };
 
 const trueResponse: CheckerResponse = structuredClone(response);
@@ -335,7 +337,7 @@ describe("Check", () => {
             // Assert
             expect(response.error).toBeDefined();
             expect(response.error?.message).toBe("Sphinx of black quartz, judge my vow");
-            expect(response.expectedType).toBe("unknown");
+            expect(response.expectedType).toBe("statement");
         }
     );
     it("Returns type mismatch when appropriate",

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
     console.error = original;
 })
 
-// TODO: Add flattening tests
+// TODO: Add augmenting tests
 
 // Generic response object
 const response: CheckerResponse = {
@@ -243,20 +243,20 @@ describe("CheckNodesEqual Expression", () => {
             expect(checkNodesEqual(termMismatch, expression, structuredClone(response)).isEqual).toBeFalsy();
         }
     );
-    it("Returns an error if the AST is not flattened",
+    it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            // This is the same as expression just unflattened
-            const unflattenedExpression: Expression = {
+            // This is the same as expression just unaugmented
+            const unaugmentedExpression: Expression = {
                 type: "expr",
                 term: structuredClone(term),
                 rest: structuredClone(particleTerm)
             }
 
             // Assert
-            expect(checkNodesEqual(unflattenedExpression, expression, structuredClone(response)).containsError).toBeTruthy();
-            expect(checkNodesEqual(unflattenedExpression, expression, structuredClone(response)).error).toEqual(
-                { message: "Received unflattened AST during checking process." }
+            expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).containsError).toBeTruthy();
+            expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).error).toEqual(
+                { message: "Received unaugmenttened AST during checking process." }
             );
 
             expect(console.error).toHaveBeenCalled();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,10 +1617,10 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inequality-grammar@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.2.2.tgz#8cf3c460a8e3ac80edd9163f7a1a3adcc8403c62"
-  integrity sha512-UotmeFDBY399rr/PSE/I9tlww/EyjzV0d5tDN/SRpIMmriPcPV75XGiOFql9h5MM0igrXa33ELeKCh2mnHpvOg==
+inequality-grammar@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.3.2.tgz#119a8afb3ea802c8abfe44bf561fde38a24a816e"
+  integrity sha512-mlwS1kXr3z60NcSXCv1CFXf7VSHXPgZzjSzN4hQSaSHJSkFGb4cJJONT3M+PiLUgUwlsjOEUBFLxE8p9V6nlWQ==
   dependencies:
     lodash "^4.17.21"
     moo "^0.5.2"


### PR DESCRIPTION
Allows for permutations of molecules to be accepted when the `allowPermutations` flag is set (off by default)
e.g. `CH3(CH2)8CH3` or `H22C10` for `C10H22` and vice-versa

---

**NOTE:** Only allows for Compound permutations of a Compound, so representing an entire Compound as a Bracket e.g. `(C5H11)2` or as a Term with a different coefficient e.g. `2 C5H11` will not work. 

The Compound can, however, be in any context such as within a Term and/or Statement.
e.g. `CH3(CH2)8CH3 -> C8H18 + C2H4`

Other changes would require a grammar rewrite, so can be handled later if wanted.

---

Also fixes `atomCount` for Expressions by keeping a separate `atomTermCount` and `atomBracketCount` to get correctly multiplied by coefficients - rather than multiplying the entire aggregate count.

This breaks many of the tests in `Chemistry.test.ts`, but the tests were based on the incorrect previous counting system so this is okay. I will make a card to fix these at some point later.