### PR TITLE
Allow Ion Chains to end with non-ion molecule

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -53,7 +53,7 @@ export interface Ion extends ASTNode {
     type: 'ion';
     molecule: Molecule;
     charge: number;
-    chain?: Ion;
+    chain?: Ion | Molecule;
     molecules?: [Molecule, number][];
 }
 export function isIon(node: ASTNode): node is Ion {
@@ -139,8 +139,13 @@ function flattenNode<T extends ASTNode>(node: T): T {
 
                 // Recursively flatten
                 if (node.chain) {
-                    const flatChain: Ion = flattenNode(node.chain);
-                    molecules = flatChain.molecules ?? [];
+                    const flatChain = flattenNode(node.chain);
+
+                    if (isIon(flatChain)) {
+                        molecules = flatChain.molecules ?? [];
+                    } else {
+                        molecules = [[flatChain, 0]]
+                    }
                 }
 
                 const flatMolecule: Molecule = flattenNode(node.molecule)


### PR DESCRIPTION
For certain acid-base questions, answers were being accepted regardless of their contents after the final charge symbol.

e.g. Answer: `H3N^{+}CH2COOH` allows `H3N^{+}` and `H3N^{+}H2O`.

This is because ion chains were only allowing Ions while flattening, whereas allowing Molecules (Elements/Compounds) in the prior grammar and subsequent processing. 

This is solved quite simply by allowing Molecules and assigning them a charge of 0.