### PR TITLE
Add optional coefficient scaling and fraction logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
-    "inequality-grammar": "^1.3.2",
+    "inequality-grammar": "^1.3.4",
     "lodash": "^4.17.21"
   }
 }

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -295,7 +295,7 @@ function typesMatch(compound1: (Element | Bracket)[], compound2: (Element | Brac
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isElement(test) && isElement(target)) {
-        if (!response.options.allowPermutations || !test.compounded) {
+        if (!response.options?.allowPermutations || !test.compounded) {
             response.sameCoefficient = response.sameCoefficient && test.coeff === target.coeff;
             response.sameElements = response.sameElements && test.value === target.value;
             response.isEqual = response.isEqual && response.sameElements && response.sameCoefficient
@@ -343,7 +343,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     else if (isCompound(test) && isCompound(target)) {
         if (test.elements && target.elements) {
 
-            if (!response.options.allowPermutations) {
+            if (!response.options?.allowPermutations) {
                 if (!isEqual(test, target)) {
                     if (test.elements.length !== target.elements.length || !typesMatch(test.elements, target.elements)) {
                         // TODO: Implement special cases for certain permutations e.g. reverse of an ion chain
@@ -356,7 +356,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
                 }
             } 
 
-            if (response.options.allowPermutations && !response.checkingPermutations) {
+            if (response.options?.allowPermutations && !response.checkingPermutations) {
                 const permutationResponse = structuredClone(response);
                 permutationResponse.checkingPermutations = true;
                 const testResponse = listComparison(test.elements, test.elements, permutationResponse, checkNodesEqual);
@@ -406,7 +406,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         const newResponse = checkNodesEqual(test.value, target.value, response);
 
         const coefficientScalingValue: Fraction = checkCoefficient(test.coeff, target.coeff);
-        if (response.options.allowScalingCoefficients) {
+        if (response.options?.allowScalingCoefficients) {
             // If first term: set the scaling value, and coefficients are equal.
             if (isEqual(newResponse.coefficientScalingValue, STARTING_COEFFICIENT)) {
                 newResponse.coefficientScalingValue = coefficientScalingValue; 
@@ -424,7 +424,6 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         if (!test.isElectron && !target.isElectron) {
             newResponse.sameState = newResponse.sameState && test.state === target.state;
-            newResponse.sameState = newResponse.sameState && !(newResponse.options.noStateSymbols && test.state !== "");
             newResponse.isEqual = newResponse.isEqual && test.state === target.state;
         } // else the 'isEqual' will already be false from the checkNodesEqual above
 

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -370,7 +370,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         } else {
             console.error("[server] Encountered unaugmented AST. Returning error");
             response.containsError = true;
-            response.error = { message: "Received unaugmented AST during checking process." };
+            response.error = "Received unaugmented AST during checking process.";
             return response;
         }
     }
@@ -394,7 +394,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         } else {
             console.error("[server] Encountered unaugmented AST. Returning error");
             response.containsError = true;
-            response.error = { message: "Received unaugmented AST during checking process." };
+            response.error = "Received unaugmented AST during checking process.";
             return response;
         }
     }
@@ -478,7 +478,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         } else {
             console.error("[server] Encountered unaugmented AST. Returning error");
             response.containsError = true;
-            response.error = { message: "Received unaugmented AST during checking process." };
+            response.error = "Received unaugmented AST during checking process.";
             return response;
         }
     }
@@ -513,7 +513,6 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions): CheckerResponse {
     const response: CheckerResponse = {
         containsError: false,
-        error: { message: "" },
         expectedType: target.result.type,
         receivedType: test.result.type,
         typeMismatch: false,
@@ -537,7 +536,7 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
                 (isParseError(test.result) ? test.result.value : "No error found");
 
         response.containsError = true;
-        response.error = { message: message };
+        response.error = message;
         response.isEqual = false;
         return response;
     }

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -446,8 +446,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     else if (isExpression(test) && isExpression(target)) {
         if (test.terms && target.terms) {
             if (test.terms.length !== target.terms.length) {
-                // TODO: add a new property stating the number of terms was wrong
-                // fail early if term lengths not the same
+                response.sameElements = false;
                 response.isEqual = false;
                 return response;
             }

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -259,7 +259,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
 }
 
-export function check(test: NuclearAST, target: NuclearAST, options: ChemistryOptions): CheckerResponse {
+export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
     const response = {
         containsError: false,
         error: { message: "" },
@@ -272,7 +272,6 @@ export function check(test: NuclearAST, target: NuclearAST, options: ChemistryOp
         isBalanced: true,
         isEqual: true,
         isNuclear: true,
-        options
     }
     // Return shortcut response
     if (target.result.type === "error" || test.result.type === "error") {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -1,4 +1,4 @@
-import { CheckerResponse, ChemicalSymbol, chemicalSymbol, listComparison } from './common'
+import { CheckerResponse, ChemicalSymbol, chemicalSymbol, ChemistryOptions, listComparison } from './common'
 
 export type ParticleString = 'alphaparticle'|'betaparticle'|'gammaray'|'neutrino'|'antineutrino'|'electron'|'positron'|'neutron'|'proton';
 export type Type = 'error'|'particle'|'isotope'|'term'|'expr'|'statement';
@@ -259,7 +259,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
 }
 
-export function check(test: NuclearAST, target: NuclearAST, allowPermutations?: boolean): CheckerResponse {
+export function check(test: NuclearAST, target: NuclearAST, options: ChemistryOptions): CheckerResponse {
     const response = {
         containsError: false,
         error: { message: "" },
@@ -272,7 +272,7 @@ export function check(test: NuclearAST, target: NuclearAST, allowPermutations?: 
         isBalanced: true,
         isEqual: true,
         isNuclear: true,
-        allowPermutations: allowPermutations ?? false,
+        options
     }
     // Return shortcut response
     if (target.result.type === "error" || test.result.type === "error") {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -231,7 +231,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         } else {
             console.error("[server] Encountered unaugmented AST. Returning error");
             response.containsError = true;
-            response.error = { message: "Received unaugmented AST during checking process." };
+            response.error = "Received unaugmented AST during checking process.";
             return response;
         }
     } else if (isStatement(test) && isStatement(target)) {
@@ -260,9 +260,8 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 }
 
 export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
-    const response = {
+    const response: CheckerResponse = {
         containsError: false,
-        error: { message: "" },
         expectedType: target.result.type,
         receivedType: test.result.type,
         typeMismatch: false,
@@ -281,7 +280,7 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
                 (isParseError(test.result) ? test.result.value : "No error found");
 
         response.containsError = true;
-        response.error = { message: message };
+        response.error = message;
         response.isEqual = false;
         return response;
    }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -3,9 +3,7 @@ export type ChemicalSymbol = typeof chemicalSymbol[number];
 
 export type ReturnType = 'term'|'expr'|'statement'|'error'|'unknown';
 
-type Aggregates = 'atomCount' | 'chargeCount' | 'nucleonCount';
-
-export interface Coefficient {
+export interface Fraction {
     numerator: number;
     denominator: number;
 }
@@ -36,12 +34,12 @@ export interface CheckerResponse {
     validAtomicNumber?: boolean;
     balancedAtom?: boolean;
     balancedMass?: boolean;
-    coefficientScalingValue?: Coefficient;
+    coefficientScalingValue?: Fraction;
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
     bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
-    atomCount?: Record<ChemicalSymbol, number | undefined>;
+    atomCount?: Record<ChemicalSymbol, Fraction | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];
 }
@@ -106,3 +104,18 @@ export function listComparison<T>(
     return possibleResponse
 }
 
+const SimplifyFrac = (frac: Fraction): Fraction => {
+    let gcd = function gcd(a: number, b:number): number{
+      return b ? gcd(b, a%b) : a;
+    };
+    const divisor = gcd(frac.numerator, frac.denominator);
+    return {numerator: frac.numerator / divisor, denominator: frac.denominator / divisor};
+}
+  
+export const AddFrac = (frac1: Fraction, frac2: Fraction): Fraction => {
+    return SimplifyFrac({numerator: frac1.numerator * frac2.denominator + frac2.numerator * frac1.denominator, denominator: frac1.denominator * frac2.denominator});
+}
+
+export const MultFrac = (frac1: Fraction, frac2: Fraction): Fraction => {
+    return SimplifyFrac({numerator: frac1.numerator * frac2.numerator, denominator: frac1.denominator * frac2.denominator});
+}

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -10,6 +10,12 @@ export interface Coefficient {
     denominator: number;
 }
 
+export interface ChemistryOptions {
+    allowPermutations: boolean;
+    allowScalingCoefficients: boolean;
+    allowStateSymbols: boolean;
+}
+
 export interface CheckerResponse {
     containsError: boolean;
     error: { message: string; };
@@ -22,7 +28,7 @@ export interface CheckerResponse {
     sameState: boolean;
     sameCoefficient: boolean;
     sameElements: boolean;
-    allowPermutations: boolean;
+    options: ChemistryOptions;
     // properties dependent on type
     sameArrow?: boolean;
     sameBrackets?: boolean;

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -11,7 +11,6 @@ export interface Fraction {
 export interface ChemistryOptions {
     allowPermutations: boolean;
     allowScalingCoefficients: boolean;
-    noStateSymbols: boolean;
 }
 
 export interface CheckerResponse {
@@ -26,7 +25,6 @@ export interface CheckerResponse {
     sameState: boolean;
     sameCoefficient: boolean;
     sameElements: boolean;
-    options: ChemistryOptions;
     // properties dependent on type
     sameArrow?: boolean;
     sameBrackets?: boolean;
@@ -42,6 +40,7 @@ export interface CheckerResponse {
     atomCount?: Record<ChemicalSymbol, Fraction | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];
+    options?: ChemistryOptions;
 }
 
 export function listComparison<T>(

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -15,7 +15,6 @@ export interface ChemistryOptions {
 
 export interface CheckerResponse {
     containsError: boolean;
-    error: { message: string; };
     expectedType: ReturnType;
     receivedType: ReturnType;
     isBalanced: boolean;
@@ -33,6 +32,7 @@ export interface CheckerResponse {
     balancedAtom?: boolean;
     balancedMass?: boolean;
     coefficientScalingValue?: Fraction;
+    error?: string;
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -13,7 +13,7 @@ export interface Coefficient {
 export interface ChemistryOptions {
     allowPermutations: boolean;
     allowScalingCoefficients: boolean;
-    allowStateSymbols: boolean;
+    noStateSymbols: boolean;
 }
 
 export interface CheckerResponse {
@@ -36,6 +36,7 @@ export interface CheckerResponse {
     validAtomicNumber?: boolean;
     balancedAtom?: boolean;
     balancedMass?: boolean;
+    coefficientScalingValue?: Coefficient;
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -30,7 +30,6 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
         // The API sends attachments as a string hashmap, so we need to convert them to boolean
         allowPermutations: req.body.allowPermutations === "true",
         allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
-        noStateSymbols: req.body.noStateSymbols === "true",
     }
     const result: CheckerResponse = check(test, target, options);
 

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from "express";
 import { ValidationChain, body, validationResult } from "express-validator";
 import { parseChemistryExpression } from "inequality-grammar";
 import { check, augment } from "../models/Chemistry";
-import { CheckerResponse } from "../models/common";
+import { CheckerResponse, ChemistryOptions } from "../models/common";
 
 const router = Router();
 
@@ -26,8 +26,13 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: ChemAST = augment(parseChemistryExpression(req.body.target)[0]);
     const test: ChemAST = augment(parseChemistryExpression(req.body.test)[0]);
-    const allowPermutations: boolean = req.body.allowPermutations === "true";
-    const result: CheckerResponse = check(test, target, allowPermutations);
+    const options: ChemistryOptions = {
+        // The API sends attachments as a string hashmap, so we need to convert them to boolean
+        allowPermutations: req.body.allowPermutations === "true",
+        allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
+        allowStateSymbols: req.body.allowStateSymbols === "true",
+    }
+    const result: CheckerResponse = check(test, target, options);
 
     res.status(201).send(result);
 

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -32,7 +32,6 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
         allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
         noStateSymbols: req.body.noStateSymbols === "true",
     }
-    console.log("options", options);
     const result: CheckerResponse = check(test, target, options);
 
     res.status(201).send(result);

--- a/src/routes/Chemistry.ts
+++ b/src/routes/Chemistry.ts
@@ -30,8 +30,9 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
         // The API sends attachments as a string hashmap, so we need to convert them to boolean
         allowPermutations: req.body.allowPermutations === "true",
         allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
-        allowStateSymbols: req.body.allowStateSymbols === "true",
+        noStateSymbols: req.body.noStateSymbols === "true",
     }
+    console.log("options", options);
     const result: CheckerResponse = check(test, target, options);
 
     res.status(201).send(result);

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -2,7 +2,7 @@ import { Request, Response, Router } from "express";
 import { ValidationChain, body, validationResult } from "express-validator";
 import { parseNuclearExpression } from "inequality-grammar";
 import { check, augment } from "../models/Nuclear";
-import { CheckerResponse } from "../models/common";
+import { CheckerResponse, ChemistryOptions } from "../models/common";
 
 const router = Router();
 
@@ -13,7 +13,7 @@ const checkValidationRules: ValidationChain[] = [
 ];
 const parseValidationRules: ValidationChain[] = [
     body('test').notEmpty().withMessage("mhChem expression is required."),
-    body('description').optional().isString().withMessage("When provided the descrition must be a string.")
+    body('description').optional().isString().withMessage("When provided the description must be a string.")
 ];
 
 router.post('/check', checkValidationRules, (req: Request, res: Response) => {
@@ -25,8 +25,13 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: NuclearAST = augment(parseNuclearExpression(req.body.target)[0]);
     const test: NuclearAST = augment(parseNuclearExpression(req.body.test)[0]);
-    const allowPermutations: boolean = req.body.allowPermutations === "true";
-    const result: CheckerResponse = check(test, target, allowPermutations);
+    const options: ChemistryOptions = {
+        // The API sends attachments as a string hashmap, so we need to convert them to boolean
+        allowPermutations: req.body.allowPermutations === "true",
+        allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
+        noStateSymbols: req.body.noStateSymbols === "true",
+    }
+    const result: CheckerResponse = check(test, target, options);
 
     res.status(201).send(result);
     

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -25,13 +25,7 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: NuclearAST = augment(parseNuclearExpression(req.body.target)[0]);
     const test: NuclearAST = augment(parseNuclearExpression(req.body.test)[0]);
-    const options: ChemistryOptions = {
-        // The API sends attachments as a string hashmap, so we need to convert them to boolean
-        allowPermutations: req.body.allowPermutations === "true",
-        allowScalingCoefficients: req.body.allowScalingCoefficients === "true",
-        noStateSymbols: req.body.noStateSymbols === "true",
-    }
-    const result: CheckerResponse = check(test, target, options);
+    const result: CheckerResponse = check(test, target);
 
     res.status(201).send(result);
     

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,10 +1617,10 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inequality-grammar@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.3.2.tgz#119a8afb3ea802c8abfe44bf561fde38a24a816e"
-  integrity sha512-mlwS1kXr3z60NcSXCv1CFXf7VSHXPgZzjSzN4hQSaSHJSkFGb4cJJONT3M+PiLUgUwlsjOEUBFLxE8p9V6nlWQ==
+inequality-grammar@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.3.4.tgz#22b34c7fbb6c61e5567f3c4a290b212500ea5881"
+  integrity sha512-LyRxj57cC8xW+OAj15WAK7hA3BblZtNLl8fDyXP9x/mn5hmd44bCCkWRsBdDqXZZZAwdmLCjPfAPJh48/sJaMw==
   dependencies:
     lodash "^4.17.21"
     moo "^0.5.2"


### PR DESCRIPTION
Adds logic for optional coefficient scaling and handling of fractions.
- e.g. `2 H2 + O2 -> 2 H2O`  ===>>> `H2 + 1/2 O2 -> H2O`

We previously made a simple check for fraction equivalence when comparing coefficients, but they weren't being used properly in atom counting. They should now be valid for that and for variable coefficients.

---
Main PR [here](https://github.com/isaacphysics/isaac-react-app/pull/1165).