### PR TITLE
Fix several small Nuclear Checker bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
-    "inequality-grammar": "^1.3.4",
+    "inequality-grammar": "^1.3.5",
     "lodash": "^4.17.21"
   }
 }

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -242,8 +242,16 @@ function augmentNode<T extends ASTNode>(node: T): T {
 }
 
 export function augment(ast: ChemAST): ChemAST {
-    const augmentedResult: Result = augmentNode(ast.result);
-    return { result: augmentedResult };
+    if (ast) {
+        return { result: augmentNode(ast.result) };
+    } else {
+        return { result: {
+            type: 'error',
+            value: "The provided AST is empty.",
+            expected: [""],
+            loc: [0,0]
+        }};
+    }
 }
 
 function checkCoefficient(coeff1: Fraction, coeff2: Fraction): Fraction {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -117,8 +117,16 @@ function augmentNode<T extends ASTNode>(node: T): T {
 }
 
 export function augment(ast: NuclearAST): NuclearAST {
-    const augmentResult: Result = augmentNode(ast.result);
-    return { result: augmentResult };
+    if (ast) {
+        return { result: augmentNode(ast.result) };
+    } else {
+        return { result: {
+            type: 'error',
+            value: "The provided AST is empty.",
+            expected: [""],
+            loc: [0,0]
+        }};
+    }
 }
 
 function isValidAtomicNumber(test: Particle | Isotope): boolean {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -167,8 +167,15 @@ function checkParticlesEqual(test: Particle, target: Particle): boolean {
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isParticle(test) && isParticle(target)) {
-        response.validAtomicNumber = isValidAtomicNumber(test);
-        response.isEqual = response.isEqual && checkParticlesEqual(test, target) && response.validAtomicNumber;
+        if (test.mass === null || test.atomic === null) {
+            response.containsError = true;
+            response.error = "Check that all atoms have a mass and atomic number!"
+            response.isEqual = false;
+            return response;
+        }
+        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
+        response.sameElements = response.sameElements && checkParticlesEqual(test, target);
+        response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
         if (response.nucleonCount) {
             response.nucleonCount = [
@@ -181,8 +188,9 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         return response;
     } else if (isIsotope(test) && isIsotope(target)) {
-        response.validAtomicNumber = isValidAtomicNumber(test);
-        response.isEqual = response.isEqual && test.element === target.element && response.validAtomicNumber;
+        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test) && test.mass === target.mass && test.atomic === target.atomic;
+        response.sameElements = response.sameElements && test.element === target.element;
+        response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
         if (response.nucleonCount) {
             response.nucleonCount = [
@@ -198,13 +206,11 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         if (test.isParticle !== target.isParticle) {
             response.sameElements = false;
             response.isEqual = false;
-            return response;
         }
 
         const newResponse = checkNodesEqual(test.value, target.value, response);
 
         newResponse.sameCoefficient = test.coeff === target.coeff;
-        newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient;
 
         if (newResponse.nucleonCount) {
             newResponse.nucleonCount = [
@@ -217,10 +223,8 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     } else if (isExpression(test) && isExpression(target)) {
         if (test.terms && target.terms) {
             if (test.terms.length !== target.terms.length) {
-                // fail early if molecule lengths not the same
                 response.sameElements = false;
                 response.isEqual = false;
-                return response;
             }
 
             return listComparison(test.terms, target.terms, response, checkNodesEqual);
@@ -247,6 +251,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         finalResponse.balancedMass = leftNucleonCount && finalResponse.nucleonCount ?
             leftNucleonCount[1] === finalResponse.nucleonCount[1] :
             false;
+        finalResponse.isEqual = finalResponse.isEqual && finalResponse.isBalanced;
 
         return finalResponse
     } else {
@@ -268,6 +273,7 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
         expectedType: target.result.type,
         receivedType: test.result.type,
         typeMismatch: false,
+        validAtomicNumber: true,
         sameState: true,
         sameCoefficient: true,
         sameElements: true,
@@ -300,6 +306,7 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
     }
 
     const newResponse = checkNodesEqual(test.result, target.result, response);
+    newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient;
     delete newResponse.nucleonCount;
     return newResponse;
 }

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -196,6 +196,12 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         return response;
     } else if (isIsotope(test) && isIsotope(target)) {
+        if (test.mass === null || test.atomic === null) {
+            response.containsError = true;
+            response.error = "Check that all atoms have a mass and atomic number!"
+            response.isEqual = false;
+            return response;
+        }
         response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test) && test.mass === target.mass && test.atomic === target.atomic;
         response.sameElements = response.sameElements && test.element === target.element;
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,10 +1617,10 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inequality-grammar@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.3.4.tgz#22b34c7fbb6c61e5567f3c4a290b212500ea5881"
-  integrity sha512-LyRxj57cC8xW+OAj15WAK7hA3BblZtNLl8fDyXP9x/mn5hmd44bCCkWRsBdDqXZZZAwdmLCjPfAPJh48/sJaMw==
+inequality-grammar@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/inequality-grammar/-/inequality-grammar-1.3.5.tgz#962faf1f99ee6f9ab97d0f4711b9c4ebcfa4424a"
+  integrity sha512-iN3Gs/8ckEQ65daS/5NDFvn0O8ULkti9GyORABTzwueZEubueMsjq7UfjIZ9ci+6yvSHYloxSZeQ7r7/aM3kAg==
   dependencies:
     lodash "^4.17.21"
     moo "^0.5.2"


### PR DESCRIPTION
### Both Checkers

- Returns an error if the provided AST is empty (e.g. if a solitary number is entered as input, as it is half correctly-parsed)

### Nuclear

- Adds a new error for missing mass/atomic numbers (incl. updating `inequality-grammar`)
- Stop failing early on non-errors, so aggregate are counted correctly 
- Set unbalanced equations to `.isEqual = false`
- Ensure validAtomicNumber is always defined, so it can be accessed by the API