### PR TITLE
Allow nested brackets

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -309,10 +309,10 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         if (test.bracketed) {
             if (response.bracketAtomCount) {
-                response.bracketAtomCount[test.value] = (response.bracketAtomCount[test.value] ?? 0) + test.coeff;
+                response.bracketAtomCount[0][test.value] = (response.bracketAtomCount[0][test.value] ?? 0) + test.coeff;
             } else {
-                response.bracketAtomCount = {} as Record<ChemicalSymbol, number | undefined>;
-                response.bracketAtomCount[test.value] = test.coeff;
+                response.bracketAtomCount = [{}] as Record<ChemicalSymbol, number | undefined>[];
+                response.bracketAtomCount[0][test.value] = test.coeff;
             }
         } else {
             if (response.termAtomCount) {
@@ -332,7 +332,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         newResponse.isEqual = newResponse.isEqual && newResponse.sameElements;
 
         if (newResponse.bracketAtomCount) {
-            for (const [key, value] of Object.entries(newResponse.bracketAtomCount)) {
+            for (const [key, value] of Object.entries(newResponse.bracketAtomCount[0])) {
                 if (newResponse.termAtomCount) {
                     newResponse.termAtomCount[key as ChemicalSymbol] = (newResponse.termAtomCount[key as ChemicalSymbol] ?? 0) + (value ?? 0) * test.coeff;
                 }
@@ -341,7 +341,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
                     newResponse.termAtomCount[key as ChemicalSymbol] = (value ?? 0) * test.coeff;
                 }
             };
-            newResponse.bracketAtomCount = {} as Record<ChemicalSymbol, number | undefined>;
+            newResponse.bracketAtomCount = [{}] as Record<ChemicalSymbol, number | undefined>[];
         }
 
         return newResponse;

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -173,6 +173,18 @@ function checkParticlesEqual(test: Particle, target: Particle): boolean {
     }
 }
 
+const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (options) => { return {
+    isNuclear: true,
+    containsError: false,
+    isEqual: true,
+    isBalanced: true,
+    typeMismatch: false,
+    sameCoefficient: true,
+    sameElements: true,
+    validAtomicNumber: true,
+    options: options ?? {},
+} };
+
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isParticle(test) && isParticle(target)) {
         if (test.mass === null || test.atomic === null) {
@@ -249,7 +261,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             return response;
         }
     } else if (isStatement(test) && isStatement(target)) {
-        const leftResponse = checkNodesEqual(test.left, target.left, response);
+        const leftResponse = checkNodesEqual(test.left, target.left, response); 
         const leftNucleonCount = leftResponse.nucleonCount;
         leftResponse.nucleonCount = [0, 0];
 
@@ -282,19 +294,10 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 }
 
 export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
-    const response: CheckerResponse = {
-        containsError: false,
-        expectedType: target.result.type,
-        receivedType: test.result.type,
-        typeMismatch: false,
-        validAtomicNumber: true,
-        sameState: true,
-        sameCoefficient: true,
-        sameElements: true,
-        isBalanced: true,
-        isEqual: true,
-        isNuclear: true,
-    }
+    const response = STARTING_RESPONSE();
+    response.expectedType = target.result.type;
+    response.receivedType = test.result.type;
+
     // Return shortcut response
     if (test.result.type === "error") {
         const message =

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -1,4 +1,4 @@
-import { CheckerResponse, ChemicalSymbol, chemicalSymbol, ChemistryOptions, listComparison } from './common'
+import { CheckerResponse, ChemicalSymbol, chemicalSymbol, ChemistryOptions, listComparison, mergeResponses, removeAggregates } from './common'
 
 export type ParticleString = 'alphaparticle'|'betaparticle'|'gammaray'|'neutrino'|'antineutrino'|'electron'|'positron'|'neutron'|'proton';
 export type Type = 'error'|'particle'|'isotope'|'term'|'expr'|'statement';
@@ -78,7 +78,7 @@ function augmentNode<T extends ASTNode>(node: T): T {
             if(isExpression(node)) {
                 let terms: Term[] = [];
 
-                // Recursively augmentten
+                // Recursively augment
                 if (node.rest) {
                     const augmentedTerms: Expression | Term = augmentNode(node.rest);
 
@@ -187,67 +187,76 @@ const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (opti
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isParticle(test) && isParticle(target)) {
+        // Answers can be entered without a mass or atomic number. However, this is always wrong so we throw an error
         if (test.mass === null || test.atomic === null) {
             response.containsError = true;
             response.error = "Check that all atoms have a mass and atomic number!"
             response.isEqual = false;
             return response;
         }
+
         response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
         response.sameElements = response.sameElements && checkParticlesEqual(test, target);
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
-        if (response.nucleonCount) {
-            response.nucleonCount = [
-                response.nucleonCount[0] + test.atomic,
-                response.nucleonCount[1] + test.mass
+        // Add the term's nucleon counts to the term's nucleon count
+        if (response.termNucleonCount) {
+            response.termNucleonCount = [
+                response.termNucleonCount[0] + test.atomic,
+                response.termNucleonCount[1] + test.mass
             ];
         } else {
-            response.nucleonCount = [test.atomic, test.mass];
+            response.termNucleonCount = [test.atomic, test.mass];
         }
 
         return response;
     } else if (isIsotope(test) && isIsotope(target)) {
+        // Answers can be entered without a mass or atomic number. However, this is always wrong so we throw an error
         if (test.mass === null || test.atomic === null) {
             response.containsError = true;
             response.error = "Check that all atoms have a mass and atomic number!"
             response.isEqual = false;
             return response;
         }
+
         response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test) && test.mass === target.mass && test.atomic === target.atomic;
         response.sameElements = response.sameElements && test.element === target.element;
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
-        if (response.nucleonCount) {
-            response.nucleonCount = [
-                response.nucleonCount[0] + test.atomic,
-                response.nucleonCount[1] + test.mass
+        // Add the term's nucleon counts to the term's nucleon count
+        if (response.termNucleonCount) {
+            response.termNucleonCount = [
+                response.termNucleonCount[0] + test.atomic,
+                response.termNucleonCount[1] + test.mass
             ];
         } else {
-            response.nucleonCount = [test.atomic, test.mass];
+            response.termNucleonCount = [test.atomic, test.mass];
         }
 
         return response;
     } else if (isTerm(test) && isTerm(target)) {
+        // If we have a particle-atom mismatch, the elements are not equivalent
         if (test.isParticle !== target.isParticle) {
             response.sameElements = false;
             response.isEqual = false;
         }
 
         const newResponse = checkNodesEqual(test.value, target.value, response);
-
+        // Set a flag for sameCoefficient here, but apply the isEqual check at the end (because of listComparison)
         newResponse.sameCoefficient = test.coeff === target.coeff;
 
+        // Add the term's nucleon counts to the overall expression nucleon count
         if (newResponse.nucleonCount) {
             newResponse.nucleonCount = [
-                newResponse.nucleonCount[0] * test.coeff,
-                newResponse.nucleonCount[1] * test.coeff,
+                newResponse.nucleonCount[0] + (newResponse.termNucleonCount ?? [0,0])[0] * test.coeff,
+                newResponse.nucleonCount[1] + (newResponse.termNucleonCount ?? [0,0])[1] * test.coeff,
             ]
         }
 
         return newResponse;
     } else if (isExpression(test) && isExpression(target)) {
         if (test.terms && target.terms) {
+            // If the number of terms in the expression is wrong, there is no way they can be equivalent
             if (test.terms.length !== target.terms.length) {
                 response.sameElements = false;
                 response.isEqual = false;
@@ -261,22 +270,21 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             return response;
         }
     } else if (isStatement(test) && isStatement(target)) {
+        // Determine responses for both the left and right side of the statement
         const leftResponse = checkNodesEqual(test.left, target.left, response); 
-        const leftNucleonCount = leftResponse.nucleonCount;
-        leftResponse.nucleonCount = [0, 0];
+        let rightResponse = STARTING_RESPONSE(leftResponse.options);
+        rightResponse = checkNodesEqual(test.right, target.right, leftResponse);
 
-        const finalResponse = checkNodesEqual(test.right, target.right, leftResponse);
+        // Merge the responses so that the final response contains all the information
+        const finalResponse = mergeResponses(leftResponse, rightResponse);
 
-        finalResponse.isBalanced = leftNucleonCount && finalResponse.nucleonCount ?
-            leftNucleonCount[0] === finalResponse.nucleonCount[0] &&
-            leftNucleonCount[1] === finalResponse.nucleonCount[1] :
-            false;
-        finalResponse.balancedAtom = leftNucleonCount && finalResponse.nucleonCount ?
-            leftNucleonCount[0] === finalResponse.nucleonCount[0] :
-            false;
-        finalResponse.balancedMass = leftNucleonCount && finalResponse.nucleonCount ?
-            leftNucleonCount[1] === finalResponse.nucleonCount[1] :
-            false;
+        // Nuclear question balance is determined by atom/mass count equality
+        finalResponse.balancedAtom = leftResponse.nucleonCount && rightResponse.nucleonCount ?
+            leftResponse.nucleonCount[0] === rightResponse.nucleonCount[0] : false;
+        finalResponse.balancedMass = leftResponse.nucleonCount && rightResponse.nucleonCount ?
+            leftResponse.nucleonCount[1] === rightResponse.nucleonCount[1] : false;
+        finalResponse.isBalanced = leftResponse.nucleonCount && rightResponse.nucleonCount ?
+            finalResponse.balancedAtom && finalResponse.balancedMass : false;
         finalResponse.isEqual = finalResponse.isEqual && finalResponse.isBalanced;
 
         return finalResponse
@@ -286,6 +294,8 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         response.isEqual = false;
         // We must still check the children of the node to get a complete nucleon count
         if (test.type == "error") {
+            response.containsError = true;
+            response.error = "Error type encountered during checking process.";
             return response;
         } else {
             return checkNodesEqual(test, test, response);
@@ -322,9 +332,10 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
         return response;
     }
 
-    const newResponse = checkNodesEqual(test.result, target.result, response);
+    let newResponse = checkNodesEqual(test.result, target.result, response);
+    // We set flags for this properties in checkNodesEqual, but we only apply the isEqual check here due to listComparison
     newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient;
-    delete newResponse.nucleonCount;
+    newResponse = removeAggregates(newResponse);
     return newResponse;
 }
 

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -1,10 +1,11 @@
+import { isEqual } from 'lodash';
 import { CheckerResponse, ChemicalSymbol, chemicalSymbol, ChemistryOptions, listComparison, mergeResponses, removeAggregates } from './common'
 
 export type ParticleString = 'alphaparticle'|'betaparticle'|'gammaray'|'neutrino'|'antineutrino'|'electron'|'positron'|'neutron'|'proton';
 export type Type = 'error'|'particle'|'isotope'|'term'|'expr'|'statement';
 export type Result = Statement | Expression | Term | ParseError;
 
-interface ASTNode {
+export interface ASTNode {
     type: Type;
 }
 
@@ -71,7 +72,7 @@ export interface NuclearAST {
     result: Result;
 }
 
-function augmentNode<T extends ASTNode>(node: T): T {
+export function augmentNode<T extends ASTNode>(node: T): T {
     // The if statements signal to the type checker what we already know
     switch (node.type) {
         case "expr": {
@@ -177,6 +178,8 @@ const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (opti
     isNuclear: true,
     containsError: false,
     isEqual: true,
+    balancedMass: true,
+    balancedAtom: true,
     isBalanced: true,
     typeMismatch: false,
     sameCoefficient: true,
@@ -195,7 +198,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             return response;
         }
 
-        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
+        response.validAtomicNumber = (response.validAtomicNumber === true) && isValidAtomicNumber(test);
         response.sameElements = response.sameElements && checkParticlesEqual(test, target);
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
@@ -219,11 +222,11 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             return response;
         }
 
-        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test) && test.mass === target.mass && test.atomic === target.atomic;
         response.sameElements = response.sameElements && test.element === target.element;
+        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test) && (response.sameElements ? test.mass === target.mass && test.atomic === target.atomic : true);
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 
-        // Add the term's nucleon counts to the term's nucleon count
+        // Add the isotope's nucleon counts to the term's nucleon count
         if (response.termNucleonCount) {
             response.termNucleonCount = [
                 response.termNucleonCount[0] + test.atomic,
@@ -246,12 +249,14 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         newResponse.sameCoefficient = test.coeff === target.coeff;
 
         // Add the term's nucleon counts to the overall expression nucleon count
-        if (newResponse.nucleonCount) {
-            newResponse.nucleonCount = [
-                newResponse.nucleonCount[0] + (newResponse.termNucleonCount ?? [0,0])[0] * test.coeff,
-                newResponse.nucleonCount[1] + (newResponse.termNucleonCount ?? [0,0])[1] * test.coeff,
-            ]
+        if (!newResponse.nucleonCount) {
+            newResponse.nucleonCount = [0,0];
         }
+        newResponse.nucleonCount = [
+            newResponse.nucleonCount[0] + (newResponse.termNucleonCount ?? [0,0])[0] * test.coeff,
+            newResponse.nucleonCount[1] + (newResponse.termNucleonCount ?? [0,0])[1] * test.coeff,
+        ]
+        newResponse.termNucleonCount = [0,0]
 
         return newResponse;
     } else if (isExpression(test) && isExpression(target)) {
@@ -273,7 +278,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         // Determine responses for both the left and right side of the statement
         const leftResponse = checkNodesEqual(test.left, target.left, response); 
         let rightResponse = STARTING_RESPONSE(leftResponse.options);
-        rightResponse = checkNodesEqual(test.right, target.right, leftResponse);
+        rightResponse = checkNodesEqual(test.right, target.right, rightResponse);
 
         // Merge the responses so that the final response contains all the information
         const finalResponse = mergeResponses(leftResponse, rightResponse);
@@ -308,6 +313,10 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
     response.expectedType = target.result.type;
     response.receivedType = test.result.type;
 
+    if (isEqual(test.result, target.result)) {
+        return response;
+    }
+
     // Return shortcut response
     if (test.result.type === "error") {
         const message =
@@ -335,7 +344,9 @@ export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
     let newResponse = checkNodesEqual(test.result, target.result, response);
     // We set flags for this properties in checkNodesEqual, but we only apply the isEqual check here due to listComparison
     newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient;
-    newResponse = removeAggregates(newResponse);
+    if (!newResponse.options?.keepAggregates) {
+        newResponse = removeAggregates(newResponse);
+    }
     return newResponse;
 }
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -23,6 +23,7 @@ export interface CheckerResponse {
     sameElements: boolean;
     // properties dependent on type
     sameState?: boolean;
+    sameCharge?: boolean;
     sameArrow?: boolean;
     sameBrackets?: boolean;
     validAtomicNumber?: boolean;
@@ -41,10 +42,10 @@ export interface CheckerResponse {
     termChargeCount?: number;
     bracketChargeCount?: number[];
     chargeCount?: Fraction;
+    termNucleonCount?: [number, number];
     nucleonCount?: [number, number];
     options?: ChemistryOptions;
 }
-
 
 export function mergeResponses(response1: CheckerResponse, response2: CheckerResponse): CheckerResponse {
     const newResponse = structuredClone(response1);
@@ -62,6 +63,18 @@ export function mergeResponses(response1: CheckerResponse, response2: CheckerRes
     newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
 
     return newResponse;
+}
+
+export function removeAggregates(response: CheckerResponse): CheckerResponse {
+    delete response.bracketChargeCount;
+    delete response.termChargeCount;
+    delete response.chargeCount;
+    delete response.bracketAtomCount;
+    delete response.termAtomCount;
+    delete response.atomCount;
+    delete response.termNucleonCount;
+    delete response.nucleonCount;
+    return response;
 }
 
 export function listComparison<T>(

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -36,7 +36,7 @@ export interface CheckerResponse {
     // book keeping
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
-    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>;
+    bracketAtomCount?: Record<ChemicalSymbol, number | undefined>[];
     atomCount?: Record<ChemicalSymbol, Fraction | undefined>;
     chargeCount?: number;
     nucleonCount?: [number, number];

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -27,8 +27,8 @@ export interface CheckerResponse {
     // properties dependent on type
     sameArrow?: boolean;
     sameBrackets?: boolean;
-    balancedCharge?: boolean;
     validAtomicNumber?: boolean;
+    isChargeBalanced?: boolean;
     balancedAtom?: boolean;
     balancedMass?: boolean;
     coefficientScalingValue?: Fraction;

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -38,7 +38,9 @@ export interface CheckerResponse {
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
     bracketAtomCount?: Record<ChemicalSymbol, number | undefined>[];
     atomCount?: Record<ChemicalSymbol, Fraction | undefined>;
-    chargeCount?: number;
+    termChargeCount?: number;
+    bracketChargeCount?: number[];
+    chargeCount?: Fraction;
     nucleonCount?: [number, number];
     options?: ChemistryOptions;
 }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -9,22 +9,20 @@ export interface Fraction {
 }
 
 export interface ChemistryOptions {
-    allowPermutations: boolean;
-    allowScalingCoefficients: boolean;
+    allowPermutations?: boolean;
+    allowScalingCoefficients?: boolean;
 }
 
 export interface CheckerResponse {
+    isNuclear: boolean;
     containsError: boolean;
-    expectedType: ReturnType;
-    receivedType: ReturnType;
     isBalanced: boolean;
     isEqual: boolean;
-    isNuclear: boolean;
     typeMismatch: boolean;
-    sameState: boolean;
     sameCoefficient: boolean;
     sameElements: boolean;
     // properties dependent on type
+    sameState?: boolean;
     sameArrow?: boolean;
     sameBrackets?: boolean;
     validAtomicNumber?: boolean;
@@ -34,6 +32,8 @@ export interface CheckerResponse {
     coefficientScalingValue?: Fraction;
     error?: string;
     // book keeping
+    expectedType?: ReturnType;
+    receivedType?: ReturnType;
     checkingPermutations? : boolean;
     termAtomCount?: Record<ChemicalSymbol, number | undefined>;
     bracketAtomCount?: Record<ChemicalSymbol, number | undefined>[];
@@ -43,6 +43,25 @@ export interface CheckerResponse {
     chargeCount?: Fraction;
     nucleonCount?: [number, number];
     options?: ChemistryOptions;
+}
+
+
+export function mergeResponses(response1: CheckerResponse, response2: CheckerResponse): CheckerResponse {
+    const newResponse = structuredClone(response1);
+
+    if (response2.containsError && !response1.containsError) {
+        newResponse.containsError = response2.containsError;
+        newResponse.error = response2.error;
+    }
+    newResponse.isEqual = response1.isEqual && response2.isEqual;
+    newResponse.typeMismatch = response1.typeMismatch || response2.typeMismatch;
+    newResponse.sameCoefficient = response1.sameCoefficient && response2.sameCoefficient;
+    newResponse.sameState = response1.sameState && response2.sameState;
+    newResponse.sameElements = response1.sameElements && response2.sameElements;
+    newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
+    newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
+
+    return newResponse;
 }
 
 export function listComparison<T>(

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -11,6 +11,7 @@ export interface Fraction {
 export interface ChemistryOptions {
     allowPermutations?: boolean;
     allowScalingCoefficients?: boolean;
+    keepAggregates?: boolean;
 }
 
 export interface CheckerResponse {
@@ -23,6 +24,7 @@ export interface CheckerResponse {
     sameElements: boolean;
     // properties dependent on type
     sameState?: boolean;
+    sameHydrate?: boolean;
     sameCharge?: boolean;
     sameArrow?: boolean;
     sameBrackets?: boolean;
@@ -57,10 +59,13 @@ export function mergeResponses(response1: CheckerResponse, response2: CheckerRes
     newResponse.isEqual = response1.isEqual && response2.isEqual;
     newResponse.typeMismatch = response1.typeMismatch || response2.typeMismatch;
     newResponse.sameCoefficient = response1.sameCoefficient && response2.sameCoefficient;
-    newResponse.sameState = response1.sameState && response2.sameState;
     newResponse.sameElements = response1.sameElements && response2.sameElements;
-    newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
-    newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
+    if (!response1.isNuclear) {
+        newResponse.sameState = response1.sameState && response2.sameState;
+        newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
+    } else {
+        newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
+    }
 
     return newResponse;
 }
@@ -123,10 +128,13 @@ export function listComparison<T>(
             returnResponse.isEqual = false;
 
             // Attach actual aggregate values
+            returnResponse.bracketChargeCount = aggregatesResponse.bracketChargeCount;
+            returnResponse.termChargeCount = aggregatesResponse.termChargeCount;
             returnResponse.chargeCount = aggregatesResponse.chargeCount;
             returnResponse.bracketAtomCount = aggregatesResponse.bracketAtomCount;
             returnResponse.termAtomCount = aggregatesResponse.termAtomCount;
             returnResponse.atomCount = aggregatesResponse.atomCount;
+            returnResponse.termNucleonCount = aggregatesResponse.termNucleonCount;
             returnResponse.nucleonCount = aggregatesResponse.nucleonCount;
 
             return returnResponse;


### PR DESCRIPTION
Allowing nested brackets is deceptively complicated compared to allowing single brackets (and only applies to the Chemistry side of the checker).

`.bracketed` is now a number value representing the number of brackets an `Element`/`Compound`/`Ion` is contained within, such that 0 or undefined represents anything unbracketed. _(This is set in the pre-processing `augmentNode` stage, where any child copies the bracketed of its parent, except a `Bracket` which increments it by one)._

`bracketAtomCount` is now an array of atom-counting `Record`s of length equal to `.bracketed` for the node (operating like a stack). `Element`s are added to the top-level `bracketAtomCount` when encountered, and the top level count is added to the second level, multiplied by the subscript `.coeff` (then popped off) when a Bracket is closed. 

`termAtomCount` functions similarly to `bracketAtomCount` but as the designated always-present bottom level of the stack. Unbracketed Elements are added directly to it, and it is multiplied by the `Term`'s leading coefficient and added to `atomCount` directly when a `Term` is closed.

`atomCount` has not changed. It is only ever incremented when a `Term` is closed, and has a `Fraction` value due to our use of `Fraction` coefficients.

The same process applies to `bracketChargeCount`, `termChargeCount`, `chargeCount` - except that charge is only ever added at an `Ion` node rather than at an `Element` node.

The Nuclear Checker has a much more basic structure with just `termNucleonCount` and `nucleonCount` in the structure `[atomCount, massCount]`. 

---

Also adds `isChargeBalanced` and `sameCharge` to the `response`, in order to allow the API to give feedback on them.

While making this change, more comments were added across the Checker to (hopefully) make it a lot clearer, as well as some restructuring work - mostly such that `Statement`s have a separate `CheckerResponse` on their left and right side to stop cross-interference. They are merged for the final `response` that is logged/sent to API.