### PR TITLE
Add and update tests for Chemistry Checker

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -377,8 +377,9 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
     else if (isIon(test) && isIon(target)) {
         if (test.molecules && target.molecules) {
-            if (test.molecules.length !== target.molecules.length) {
+            if (!response.options?.allowPermutations && test.molecules.length !== target.molecules.length) {
                 // fail early if molecule lengths not the same
+                response.sameElements = false;
                 response.isEqual = false;
                 return response;
             }
@@ -531,10 +532,10 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
 
 
     const newResponse = checkNodesEqual(test.result, target.result, response);
-    delete newResponse.chargeCount;
+    /* delete newResponse.chargeCount;
     delete newResponse.termAtomCount;
     delete newResponse.bracketAtomCount;
-    delete newResponse.atomCount;
+    delete newResponse.atomCount; */
     return newResponse;
 }
 

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -580,7 +580,7 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
     response.expectedType = target.result.type;
     response.receivedType = test.result.type;
 
-    if (isEqual(test.result, target.result) && !options.keepAggregates) {
+    if (!options.keepAggregates && isEqual(test.result, target.result)) {
         return response;
     }
 

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -109,9 +109,9 @@ export interface ChemAST {
     result: Result;
 }
 
-const STARTING_COEFFICIENT: Fraction = { numerator: 0, denominator: 1 };
-const ERROR_COEFFICIENT: Fraction = { numerator: -1, denominator: -1 };
-const EQUAL_COEFFICIENT: Fraction = { numerator: 1, denominator: 1 };
+export const STARTING_COEFFICIENT: Fraction = { numerator: 0, denominator: 1 };
+export const ERROR_COEFFICIENT: Fraction = { numerator: -1, denominator: -1 };
+export const EQUAL_COEFFICIENT: Fraction = { numerator: 1, denominator: 1 };
 
 function augmentNode<T extends ASTNode>(node: T): T {
     // The if statements signal to the type checker what we already know

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -7,7 +7,7 @@ export type Arrow = 'SArr'|'DArr';
 export type Molecule = Element | Compound;
 export type Result = Statement | Expression | Term | ParseError;
 
-interface ASTNode {
+export interface ASTNode {
     type: Type;
 }
 
@@ -111,7 +111,7 @@ export interface ChemAST {
     result: Result;
 }
 
-const STARTING_COEFFICIENT: Fraction = { numerator: 0, denominator: 1 };
+export const STARTING_COEFFICIENT: Fraction = { numerator: 0, denominator: 1 };
 const EQUAL_COEFFICIENT: Fraction = { numerator: 1, denominator: 1 };
 
 const STARTING_RESPONSE: (options?: ChemistryOptions, coefficientScalingValue?: Fraction) => CheckerResponse = (options, coefficientScalingValue) => { return {
@@ -579,6 +579,10 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
     response.expectedType = target.result.type;
     response.receivedType = test.result.type;
 
+    if (isEqual(test.result, target.result)) {
+        return response;
+    }
+
     // Return shortcut response
     if (test.result.type === "error") {
         const message =
@@ -607,7 +611,9 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
     // We set flags for these properties in checkNodesEqual, but we only apply the isEqual check here due to listComparison
     newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && (newResponse.sameState == true) && (newResponse.sameBrackets == true);
 
-    newResponse = removeAggregates(newResponse);
+    if (!newResponse.options?.keepAggregates) {
+        newResponse = removeAggregates(newResponse);
+    }
     return newResponse;
 }
 

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -123,6 +123,7 @@ const STARTING_RESPONSE: (options?: ChemistryOptions, coefficientScalingValue?: 
     sameCoefficient: true,
     sameElements: true,
     sameState: true,
+    sameHydrate: true,
     sameCharge: true,
     sameArrow: true,
     sameBrackets: true,
@@ -493,7 +494,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         }
 
         newResponse.sameState = newResponse.sameState && test.state === target.state;
-        // TODO: add a new property stating the hydrate was wrong?
+        newResponse.sameHydrate = newResponse.sameHydrate && test.isHydrate === target.isHydrate && test.hydrate === target.hydrate;
 
         // Add the term's atomCount (* coefficient) to the overall expression atomCount
         if (newResponse.termAtomCount) {
@@ -579,7 +580,7 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
     response.expectedType = target.result.type;
     response.receivedType = test.result.type;
 
-    if (isEqual(test.result, target.result)) {
+    if (isEqual(test.result, target.result) && !options.keepAggregates) {
         return response;
     }
 
@@ -609,7 +610,7 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
 
     let newResponse = checkNodesEqual(test.result, target.result, response);
     // We set flags for these properties in checkNodesEqual, but we only apply the isEqual check here due to listComparison
-    newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && (newResponse.sameState == true) && (newResponse.sameBrackets == true);
+    newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && (newResponse.sameState === true) && (newResponse.sameBrackets === true) && (newResponse.sameHydrate === true);
 
     if (!newResponse.options?.keepAggregates) {
         newResponse = removeAggregates(newResponse);

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -124,7 +124,6 @@ const STARTING_RESPONSE: (options?: ChemistryOptions, coefficientScalingValue?: 
     sameHydrate: true,
     sameElements: true,
     sameState: true,
-    sameHydrate: true,
     sameCharge: true,
     sameArrow: true,
     sameBrackets: true,

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -309,12 +309,12 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
 }
 
-export function check(test: NuclearAST, target: NuclearAST): CheckerResponse {
-    const response = STARTING_RESPONSE();
+export function check(test: NuclearAST, target: NuclearAST, options: ChemistryOptions): CheckerResponse {
+    const response = STARTING_RESPONSE(options);
     response.expectedType = target.result.type;
     response.receivedType = test.result.type;
 
-    if (isEqual(test.result, target.result)) {
+    if (!options.keepAggregates && isEqual(test.result, target.result)) {
         return response;
     }
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -93,7 +93,9 @@ export function listComparison<T>(
             returnResponse.bracketAtomCount = aggregatesResponse.bracketAtomCount;
             returnResponse.termAtomCount = aggregatesResponse.termAtomCount;
             returnResponse.atomCount = aggregatesResponse.atomCount;
-            returnResponse.nucleonCount = aggregatesResponse.nucleonCount;
+            if (aggregatesResponse.nucleonCount) {
+                returnResponse.nucleonCount = aggregatesResponse.nucleonCount;
+            }
 
             return returnResponse;
         }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -11,6 +11,7 @@ export interface Fraction {
 export interface ChemistryOptions {
     allowPermutations?: boolean;
     allowScalingCoefficients?: boolean;
+    keepAggregates?: boolean;
 }
 
 export interface CheckerResponse {
@@ -57,10 +58,13 @@ export function mergeResponses(response1: CheckerResponse, response2: CheckerRes
     newResponse.isEqual = response1.isEqual && response2.isEqual;
     newResponse.typeMismatch = response1.typeMismatch || response2.typeMismatch;
     newResponse.sameCoefficient = response1.sameCoefficient && response2.sameCoefficient;
-    newResponse.sameState = response1.sameState && response2.sameState;
     newResponse.sameElements = response1.sameElements && response2.sameElements;
-    newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
-    newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
+    if (!response1.isNuclear) {
+        newResponse.sameState = response1.sameState && response2.sameState;
+        newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
+    } else {
+        newResponse.validAtomicNumber = response1.validAtomicNumber && response2.validAtomicNumber;
+    }
 
     return newResponse;
 }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -24,6 +24,7 @@ export interface CheckerResponse {
     sameElements: boolean;
     // properties dependent on type
     sameState?: boolean;
+    sameHydrate?: boolean;
     sameCharge?: boolean;
     sameArrow?: boolean;
     sameBrackets?: boolean;

--- a/src/routes/Nuclear.ts
+++ b/src/routes/Nuclear.ts
@@ -25,7 +25,7 @@ router.post('/check', checkValidationRules, (req: Request, res: Response) => {
 
     const target: NuclearAST = augment(parseNuclearExpression(req.body.target)[0]);
     const test: NuclearAST = augment(parseNuclearExpression(req.body.test)[0]);
-    const result: CheckerResponse = check(test, target);
+    const result: CheckerResponse = check(test, target, {});
 
     res.status(201).send(result);
     

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -1,3 +1,4 @@
+import exp from "constants";
 import { Bracket, Compound, Element, exportedForTesting, Ion, Term, Expression, Statement, ParseError, check, ChemAST, augment, STARTING_COEFFICIENT, Result, ASTNode, isExpression } from "../../src/models/Chemistry";
 import { CheckerResponse, listComparison, ChemistryOptions } from "../../src/models/common";
 const { augmentNode } = exportedForTesting;
@@ -124,6 +125,9 @@ const statement: Statement = {
     right: structuredClone(expression),
     arrow: "SArr"
 }
+if ("rest" in statement.right && statement.right.rest && "hydrate" in statement.right.rest) {
+    statement.right.rest.hydrate = 1;
+}
 const augmentedStatement: Statement = augmentNode(structuredClone(statement));
 
 const ast: ChemAST = {
@@ -156,36 +160,39 @@ describe("listComparison", () => {
 
     it("Returns truthy CheckerResponse when lists match",
         () => {
-            // Act
+            // Arrange
             const l1: number[] = [1, 2, 3, 4];
             const l2: number[] = [2, 4, 1, 3];
 
+            // Act
+            const testComparison = listComparison(l1, l2, structuredClone(response), comparatorNumberMock)
+
             // Assert
-            expect(
-                listComparison(l1, l2, structuredClone(response), comparatorNumberMock).isEqual
-            ).toBeTruthy();
+            expect(testComparison.isEqual).toBeTruthy();
         }
     );
     it("Returns falsy CheckerResponse when lists don't match",
         () => {
-            // Act
+            // Arrange
             const l1: number[] = [1, 2, 3, 4];
             const l2: number[] = [2, 5, 1, 3];
 
+            // Act
+            const testComparison = listComparison(l1, l2, structuredClone(response), comparatorNumberMock)
+
             // Assert
-            expect(
-                listComparison(l1, l2, structuredClone(response), comparatorNumberMock).isEqual
-            ).toBeFalsy();
+            expect(testComparison.isEqual).toBeFalsy();
         }
     );
     it("Returns updated CheckerResponse if it changes",
         () => {
-            // Act
+            // Arrange
             const match1: number[] = [1, 2, 3, 4];
             const match2: number[] = [2, 4, 1, 3];
             const mismatch1: number[] = [1, 2, 3, 4];
             const mismatch2: number[] = [2, 5, 1, 3];
 
+            // Act
             const matchResponse = listComparison(match1, match2, structuredClone(response), comparatorResponseChangeMock);
             const mismatchResponse = listComparison(mismatch1, mismatch2, structuredClone(response), comparatorResponseChangeMock);
 
@@ -199,9 +206,10 @@ describe("listComparison", () => {
 describe("testCheck Elements", () => {
     it("Returns truthy CheckerResponse when elements match",
         () => {
-            // Act
+            // Arrange
             const elementCopy: Element = structuredClone(element)
 
+            // Act
             const testResponse = testCheck(elementCopy, element, { keepAggregates: true });
 
             // Assert
@@ -212,12 +220,13 @@ describe("testCheck Elements", () => {
     );
     it("Returns falsy CheckerResponse when elements don't match",
         () => {
-            // Act
+            // Arrange
             const valueMismatch: Element = structuredClone(element);
             valueMismatch.value = "O";
             const coefficientMismatch: Element = structuredClone(element);
             coefficientMismatch.coeff = 2;
 
+            // Act
             const elementIncorrect = testCheck(valueMismatch, element, { keepAggregates: true });
             const coeffIncorrect = testCheck(coefficientMismatch, element, { keepAggregates: true });
 
@@ -234,9 +243,10 @@ describe("testCheck Elements", () => {
 describe("testCheck Brackets", () => {
     it("Returns truthy CheckerResponse when brackets match",
         () => {
-            // Act
+            // Arrange
             const bracketCopy: Bracket = structuredClone(bracket);
 
+            // Act
             const testResponse = testCheck(bracketCopy, bracket, { keepAggregates: true });
 
             // Assert
@@ -246,10 +256,11 @@ describe("testCheck Brackets", () => {
     );
     it("Returns falsy CheckerResponse when brackets don't match",
         () => {
-            // Act
+            // Arrange
             const coefficientMismatch: Bracket = structuredClone(bracket);
             coefficientMismatch.coeff = 2;
 
+            // Act
             const coeffIncorrect = testCheck(coefficientMismatch, bracket, { keepAggregates: true });
 
             // Assert
@@ -262,9 +273,10 @@ describe("testCheck Brackets", () => {
 describe("testCheck Compounds", () => {
     it("Returns truthy CheckerResponse when compounds match",
         () => {
-            // Act
+            // Arrange
             const compoundCopy: Compound = structuredClone(compound);
 
+            // Act
             const testResponse = testCheck(compoundCopy, structuredClone(compound), { keepAggregates: true });
 
             // Assert
@@ -275,7 +287,7 @@ describe("testCheck Compounds", () => {
     );
     it("Returns truthy CheckerResponse when a permutation of compounds match with allowPermutations",
         () => {
-            // Act
+            // Arrange
             const permutedCompound: Compound = structuredClone(compound);
             permutedCompound.elements?.reverse;
 
@@ -284,6 +296,7 @@ describe("testCheck Compounds", () => {
             
             const permutationsOptions = { allowPermutations: true };
 
+            // Act
             const testResponse = testCheck(permutedCompound, structuredClone(compound), permutationsOptions);
             const hydrocarbonResponse = testCheck(hydrocarbonCompound, permutedHydrocarbonCompound, permutationsOptions);
 
@@ -294,12 +307,13 @@ describe("testCheck Compounds", () => {
     );
     it("Returns falsy CheckerResponse when compounds don't match",
         () => {
-            // Act
+            // Arrange
             const typeMismatch: Compound = structuredClone(compound);
             typeMismatch.elements = [structuredClone(element), structuredClone(element)];
             const lengthMismatch: Compound = augmentNode(structuredClone(compound));
             lengthMismatch.elements?.push(structuredClone(element));
 
+            // Act
             const typesIncorrect = unaugmentedTestCheck(typeMismatch, augmentNode(structuredClone(compound)));
             const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentNode(structuredClone(compound)));
 
@@ -326,6 +340,7 @@ describe("testCheck Compounds", () => {
             const elementMismatch: Compound = structuredClone(compound);
             elementMismatch.elements = [elementCoeffMismatch];
 
+            // Act
             const bracketResponse: CheckerResponse = testCheck(bracketCoeffMismatch, structuredClone(bracket));
             const elementResponse: CheckerResponse = testCheck(elementCoeffMismatch, structuredClone(element));
 
@@ -336,9 +351,12 @@ describe("testCheck Compounds", () => {
     );
     it("Returns an error if the AST is not augmented",
         () => {
+            // Act
+            const testResponse = unaugmentedTestCheck(structuredClone(compound), augmentedCompound, { keepAggregates: true });
+            
             // Assert
-            expect(unaugmentedTestCheck(structuredClone(compound), augmentedCompound, { keepAggregates: true }).containsError).toBeTruthy();
-            expect(unaugmentedTestCheck(structuredClone(compound), augmentedCompound, { keepAggregates: true }).error).toEqual("Received unaugmented AST during checking process.");
+            expect(testResponse.containsError).toBeTruthy();
+            expect(testResponse.error).toEqual("Received unaugmented AST during checking process.");
 
             expect(console.error).toHaveBeenCalled();
         }
@@ -348,9 +366,10 @@ describe("testCheck Compounds", () => {
 describe("testCheck Ions", () => {
     it("Returns truthy CheckerResponse when ions match",
         () => {
-            // Act
+            // Arrange
             const ionClone: Ion = structuredClone(ion);
 
+            // Act
             const testResponse = testCheck(structuredClone(ion), ionClone, { keepAggregates: true });
 
             // Assert
@@ -363,12 +382,13 @@ describe("testCheck Ions", () => {
     );
     it("Returns truthy CheckerResponse when a permutation of ions match with allowPermutations",
         () => {
-            // Act
+            // Arrange
             const permutedIon: Ion = structuredClone(ion);
             permutedIon.molecules?.reverse;
 
             const permutationsOptions = { allowPermutations: true, keepAggregates: true };
 
+            // Act
             const testResponse = testCheck(permutedIon, structuredClone(ion), permutationsOptions);
 
             // Assert
@@ -376,39 +396,60 @@ describe("testCheck Ions", () => {
             expect(testResponse.termChargeCount).toBe(0);
         }
     );
-    it("Returns falsy CheckerResponse when ions don't match",
+    it("Returns falsy CheckerResponse when ions have mismatched molecules",
         () => {
+            // Arrange
             const moleculeMismatch: Ion = structuredClone(augmentedIon);
             if (moleculeMismatch.molecules) {
                 moleculeMismatch.molecules[0] = [{ type: "element", value: "Cl", coeff: 1 }, -1];
             }
 
-            const chargeMismatch: Ion = structuredClone(augmentedIon);
-            if (chargeMismatch.molecules) {
-                chargeMismatch.molecules[0] = [{ type: "element", value: "Na", coeff: 1 }, -1]
-            }
-
-            const lengthMismatch: Ion = structuredClone(augmentedIon);
-            lengthMismatch.molecules?.push([structuredClone(element), 1]);
-
+            // Act
             const moleculeIncorrect = unaugmentedTestCheck(moleculeMismatch, structuredClone(augmentedIon), { keepAggregates: true });
-            const chargeIncorrect = unaugmentedTestCheck(chargeMismatch, structuredClone(augmentedIon), { keepAggregates: true });
-            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, structuredClone(augmentedIon), { keepAggregates: true});
 
             // Assert
             expect(moleculeIncorrect.isEqual).toBeFalsy();
             expect(moleculeIncorrect.typeMismatch).toBeFalsy();
             expect(moleculeIncorrect.termAtomCount?.Cl).toBe(1);
+        }
+    );
+    it("Returns falsy CheckerResponse when ions have mismatched charges",
+        () => {
+            // Arrange
+            const chargeMismatch: Ion = structuredClone(augmentedIon);
+            if (chargeMismatch.molecules) {
+                chargeMismatch.molecules[0] = [{ type: "element", value: "Na", coeff: 1 }, -1]
+            }
+
+            // Act
+            const chargeIncorrect = unaugmentedTestCheck(chargeMismatch, structuredClone(augmentedIon), { keepAggregates: true });
+
+            // Assert
             expect(chargeIncorrect.isEqual).toBeFalsy();
             expect(chargeIncorrect.termChargeCount).toBe(-2);
+        }
+    );
+    it("Returns falsy CheckerResponse when ions have mismatched length",
+        () => {
+            // Arrange
+            const lengthMismatch: Ion = structuredClone(augmentedIon);
+            lengthMismatch.molecules?.push([structuredClone(element), 1]);
+
+            // Act
+            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, structuredClone(augmentedIon), { keepAggregates: true});
+
+            // Assert
             expect(lengthIncorrect.isEqual).toBeFalsy();
         }
     );
     it("Returns an error if the AST is not augmented",
         () => {
+            // Act
+            const testResponse = unaugmentedTestCheck(structuredClone(ion), augmentedIon);
+
             // Assert
-            expect(unaugmentedTestCheck(structuredClone(ion), augmentedIon).containsError).toBeTruthy();
-            expect(unaugmentedTestCheck(structuredClone(ion), augmentedIon).error).toEqual("Received unaugmented AST during checking process.");
+            expect(testResponse.containsError).toBeTruthy();
+            expect(testResponse.error).toEqual("Received unaugmented AST during checking process.");
 
             expect(console.error).toHaveBeenCalled();
         }
@@ -418,11 +459,12 @@ describe("testCheck Ions", () => {
 describe("testCheck Term", () => {
     it("Returns truthy CheckerResponse when terms have equal states", 
         () => {
-            // Act
+            // Arrange
             const stateTerm = structuredClone(term);
             stateTerm.state = "(aq)";
             let stateTermCopy: Term = structuredClone(stateTerm);
 
+            // Act
             const testResponse = testCheck(stateTerm, stateTermCopy)
 
             // Assert
@@ -432,36 +474,43 @@ describe("testCheck Term", () => {
     );
     it("Returns truthy CheckerResponse when terms has equal hydrates", 
         () => {
-            // Act
+            // Arrange
             const hydratedTerm = structuredClone(term);
             hydratedTerm.isHydrate = true;
             hydratedTerm.hydrate = 7;
             const hydratedTermCopy = structuredClone(hydratedTerm);
 
+            // Act
+            const testResponse = testCheck(hydratedTermCopy, hydratedTerm);
+
             // Assert
-            expect(testCheck(hydratedTermCopy, hydratedTerm).isEqual).toBeTruthy();
+            expect(testResponse.isEqual).toBeTruthy();
         }
     );
     it("Returns truthy CheckerResponse when electron terms match",
         () => {
-            // Act
+            // Arrange
             const electronTerm = structuredClone(term);
             electronTerm.isElectron = true
             electronTerm.value = { type: "electron" }
             const electronTermCopy = structuredClone(electronTerm);
 
+            // Act
+            const testResponse = testCheck(electronTermCopy, electronTerm);
+
             // Assert
-            expect(testCheck(electronTermCopy, electronTerm).isEqual).toBeTruthy();
+            expect(testResponse.isEqual).toBeTruthy();
         }
     );
     it("Returns truthy CheckerResponse when terms match with allowScalingCoefficients", 
         () => {
-            // Act   
+            // Arrange  
             const scaledOptions = { allowScalingCoefficients: true, keepAggregates: true };
 
             const perturbedTerm: Term = structuredClone(term);
             perturbedTerm.coeff = { numerator: 6, denominator: 4 };
 
+            // Act
             const testResponse = testCheck(perturbedTerm, structuredClone(term), scaledOptions);
 
             // Assert
@@ -469,46 +518,78 @@ describe("testCheck Term", () => {
             expect(testResponse.atomCount?.O).toEqual({"numerator": 3, "denominator": 2});
         }
     );
-    it("Returns falsy CheckerResponse when terms don't match",
+    it("Returns falsy CheckerResponse when terms have mismatched coefficients", // to seperate (working on it)
         () => {
-            // Mismatched coefficients
-            let mismatchTerm: Term = structuredClone(term);
+            // Arrange
+            const mismatchTerm: Term = structuredClone(term);
             mismatchTerm.coeff = { numerator: 1, denominator: 5 };
 
-            expect(testCheck(mismatchTerm, structuredClone(term)).isEqual).toBeFalsy();
-            expect(testCheck(mismatchTerm, structuredClone(term)).sameCoefficient).toBeFalsy();
+            // Act
+            const testResponse = testCheck(mismatchTerm, structuredClone(term));
 
-            // Mismatched state
-            let perturbedTerm: Term = structuredClone(term);
-            mismatchTerm = structuredClone(term);
+            // Assert
+            expect(testResponse.isEqual).toBeFalsy();
+            expect(testResponse.sameCoefficient).toBeFalsy();
+        }
+    )
+    it("Returns falsy CheckerResponse when terms have mismatched states",
+        () => {
+            // Arrange
+            const perturbedTerm: Term = structuredClone(term);
+            const mismatchTerm = structuredClone(term);
+
             perturbedTerm.state = "(aq)";
             mismatchTerm.state = "(g)";
-            expect(testCheck(perturbedTerm, mismatchTerm).isEqual).toBeFalsy();
-            expect(testCheck(perturbedTerm, mismatchTerm).sameState).toBeFalsy();
 
-            // Mismatched hydrate
-            perturbedTerm = structuredClone(term);
-            mismatchTerm = structuredClone(term);
+            // Act
+            const testResponse = testCheck(perturbedTerm, mismatchTerm);
+
+            // Assert
+            expect(testResponse.isEqual).toBeFalsy();
+            expect(testResponse.sameState).toBeFalsy();
+        }
+    )
+    it("Returns falsy CheckerResponse when terms have mismatched hydrates",
+        () => {
+            // Arrange
+            const perturbedTerm = structuredClone(term);
+            const mismatchTerm = structuredClone(term);
+
             perturbedTerm.isHydrate = true;
             perturbedTerm.hydrate = 7;
+
             mismatchTerm.isHydrate = true;
             mismatchTerm.hydrate = 1;
-            expect(testCheck(perturbedTerm, mismatchTerm).isEqual).toBeFalsy();
 
-            // Mismatched type
-            mismatchTerm = structuredClone(term);
+            // Act
+            const testResponse = testCheck(perturbedTerm, mismatchTerm);
+
+            // Assert
+            expect(testResponse.isEqual).toBeFalsy();
+        }
+    )
+    it("Returns falsy CheckerResponse when terms have mismatched types",
+        () => {
+            // Arrange
+            const mismatchTerm = structuredClone(term);
             mismatchTerm.isElectron = true;
             mismatchTerm.value = { type: "electron" };
-            expect(testCheck(mismatchTerm, structuredClone(term)).isEqual).toBeFalsy();
-            expect(testCheck(mismatchTerm, structuredClone(term)).typeMismatch).toBeFalsy();
+
+            // Act
+            const testResponse = testCheck(mismatchTerm, structuredClone(term));
+
+            // Assert
+            expect(testResponse.isEqual).toBeFalsy();
+            expect(testResponse.typeMismatch).toBeFalsy();
         }
-    );
+    )
     it("Retains CheckerResponse properties",
         () => {
-            // Act
+            // Arrange
             const complexTerm: Term = structuredClone(term);
             complexTerm.value = structuredClone(compound);
 
+            // Act
             const testResponse = testCheck(complexTerm, structuredClone(term));
             const compoundResponse = testCheck(structuredClone(compound), minimalCompound);
 
@@ -521,12 +602,14 @@ describe("testCheck Term", () => {
 describe("testCheck Expression", () => {
     it("Returns truthy CheckerResponse when expressions match",
         () => {
-            // Act
+            // Arrange
             const permutedExpression: Expression = structuredClone(augmentedExpression);
             permutedExpression.terms?.reverse;
             permutedExpression.term = permutedExpression.terms ? permutedExpression.terms[0] : permutedExpression.term;
 
+            // Act
             const testResponse: CheckerResponse = unaugmentedTestCheck(permutedExpression, augmentedExpression, { keepAggregates: true });
+
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
             expect(testResponse.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
@@ -534,7 +617,7 @@ describe("testCheck Expression", () => {
     );
     it("Returns truthy CheckerResponse when expressions match with allowScalingCoefficients", 
         () => {
-            // Act   
+            // Arrange 
             const scaledOptions = { allowScalingCoefficients: true, keepAggregates: true };
 
             const perturbedExpression: Expression = structuredClone(augmentedExpression);
@@ -543,6 +626,7 @@ describe("testCheck Expression", () => {
                                              {...perturbedExpression.terms[1], coeff: { numerator: 16, denominator: 8} }];
             }
 
+            // Act
             const testResponse = unaugmentedTestCheck(perturbedExpression, structuredClone(augmentedExpression), scaledOptions);
 
             // Assert
@@ -552,21 +636,25 @@ describe("testCheck Expression", () => {
     );
     it("Returns falsy CheckerResponse when expressions don't match",
         () => {
-            // Act
+            // Arrange
             const lengthMismatch: Expression = structuredClone(augmentedExpression);
             lengthMismatch.terms?.push(structuredClone(hydrate));
 
             const termMismatch: Expression = structuredClone(augmentedExpression);
             if (termMismatch.terms) termMismatch.terms[1] = structuredClone(hydrate);
 
+            // Act
+            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedExpression);
+            const termIncorrect = unaugmentedTestCheck(termMismatch, augmentedExpression);
+
             // Assert
-            expect(unaugmentedTestCheck(lengthMismatch, augmentedExpression).isEqual).toBeFalsy();
-            expect(unaugmentedTestCheck(termMismatch, augmentedExpression).isEqual).toBeFalsy();
+            expect(lengthIncorrect.isEqual).toBeFalsy();
+            expect(termIncorrect.isEqual).toBeFalsy();
         }
     );
     it("Retains CheckerResponse properties",
         () => {
-            // Act
+            // Arrange
             const adjustedExpression: Expression = structuredClone(expression);
             adjustedExpression.term = structuredClone(hydrate);
             adjustedExpression.terms = [structuredClone(hydrate)];
@@ -575,6 +663,7 @@ describe("testCheck Expression", () => {
             mismatchedHydrate.term = structuredClone(hydrate2);
             mismatchedHydrate.terms = [structuredClone(hydrate2)];
 
+            // Act
             const hydrateResponse: CheckerResponse = testCheck(hydrate, hydrate2);
 
             // Assert
@@ -583,9 +672,12 @@ describe("testCheck Expression", () => {
     );
     it("Returns an error if the AST is not augmented",
         () => {
+            // Act
+            const testResponse = unaugmentedTestCheck(structuredClone(expression), augmentedExpression);
+
             // Assert
-            expect(unaugmentedTestCheck(structuredClone(expression), augmentedExpression).containsError).toBeTruthy();
-            expect(unaugmentedTestCheck(structuredClone(expression), augmentedExpression).error).toEqual("Received unaugmented AST during checking process.");
+            expect(testResponse.containsError).toBeTruthy();
+            expect(testResponse.error).toEqual("Received unaugmented AST during checking process.");
 
             expect(console.error).toHaveBeenCalled();
         }
@@ -595,14 +687,17 @@ describe("testCheck Expression", () => {
 describe("testCheck Statement", () => {
     it("Returns truthy CheckerResponse when expressions match",
         () => {
-            // Act
+            // Arrange
             const copy: Statement = structuredClone(statement);
 
             const copyResult: CheckerResponse = testCheck(copy, statement);
 
             copy.arrow = "DArr";
             const doubleArrowCopy: Statement = structuredClone(copy);
+
+            // Act
             const arrowResult = testCheck(copy, doubleArrowCopy);
+
             // Assert
             expect(copyResult.isEqual).toBeTruthy();
             expect(copyResult.sameArrow).toBeTruthy();
@@ -613,7 +708,7 @@ describe("testCheck Statement", () => {
     );
     it("Returns truthy CheckerResponse when statements match with allowScalingCoefficients", 
         () => {
-            // Act
+            // Arrange
             const scaledOptions = { allowScalingCoefficients: true, keepAggregates: true };
 
             const perturbedStatement: Statement = structuredClone(augmentedStatement);
@@ -624,6 +719,7 @@ describe("testCheck Statement", () => {
                                                   {...perturbedStatement.right.terms[1],  coeff: { numerator: 1, denominator: 3} }];                         
             }
 
+            // Act
             const testResponse = unaugmentedTestCheck(perturbedStatement, structuredClone(augmentedStatement), scaledOptions);
 
             // Assert
@@ -633,7 +729,7 @@ describe("testCheck Statement", () => {
     );
     it("Returns falsy CheckerResponse when expressions don't match",
         () => {
-            // Act
+            // Arrange
             const swappedExpressions: Statement = structuredClone(statement);
             const tempExpression = swappedExpressions.left;
             swappedExpressions.left = swappedExpressions.right;
@@ -642,6 +738,7 @@ describe("testCheck Statement", () => {
             const doubleArrow: Statement = structuredClone(statement);
             doubleArrow.arrow = "DArr";
 
+            // Act
             const swapResult = testCheck(swappedExpressions, statement);
             const arrowResult = testCheck(doubleArrow, statement);
 
@@ -652,41 +749,80 @@ describe("testCheck Statement", () => {
             expect(arrowResult.sameArrow).toBeFalsy();
         }
     );
-    it("Correctly checks whether statements are balanced",
+    it("Returns truthy CheckerResponse when statements are balanced", 
+        () => {
+            // Act
+            const balancedCheck = testCheck(statement, statement, { keepAggregates: true});
+
+            // Asssert
+            expect(balancedCheck.isEqual).toBeTruthy();
+            expect(balancedCheck.isBalanced).toBeTruthy();
+            expect(balancedCheck.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
+        }
+    );
+    it("Returns falsy CheckerResponse when statements are unbalanced", 
         () => {
             // Arrange
             const unbalancedStatement: Statement = structuredClone(statement);
             // expression has two atoms unlike statements single right expression
-            unbalancedStatement.right = structuredClone(expression);
+            unbalancedStatement.right = structuredClone(hydrate);
 
-            // Assert
-            expect((testCheck(statement, unbalancedStatement)).isBalanced).toBeTruthy();
-            expect((testCheck(unbalancedStatement, statement)).isBalanced).toBeFalsy();
+            // Act
+            const unbalancedCheck = testCheck(unbalancedStatement, statement, { keepAggregates: true});
+
+            // Asssert
+            expect(unbalancedCheck.isEqual).toBeFalsy();
+            expect(unbalancedCheck.isBalanced).toBeFalsy();
+            expect(unbalancedCheck.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
         }
     );
-    it("Correctly checks whether charges are balanced",
+    it("Returns truthy CheckerResponse when statements charges are balanced", 
         () => {
             // Arrange
-            const chargedIon: Ion = augmentedIon;
+            const chargedIon: Ion = structuredClone(augmentedIon);
             chargedIon.molecules = [[structuredClone(element), 1]];
 
             const chargedTerm: Term = augmentNode(structuredClone(term));
             chargedTerm.value = chargedIon;
 
-            // expression is otherwise neutral
-            const chargedExpr: Expression = augmentedExpression;
+            const chargedExpr: Expression = structuredClone(augmentedExpression);
             chargedExpr.terms?.push(chargedTerm);
 
             const balancedCharges: Statement = augmentNode(structuredClone(statement));
             balancedCharges.left = structuredClone(chargedExpr);
             balancedCharges.right = structuredClone(chargedExpr);
 
+            // Act
+            const balancedCheck = unaugmentedTestCheck(balancedCharges, balancedCharges, { keepAggregates: true });
+
+            // Assert
+            expect(balancedCheck.isEqual).toBeTruthy();
+            expect(balancedCheck.isChargeBalanced).toBeTruthy();
+            expect(balancedCheck.chargeCount).toEqual({"numerator": 3, "denominator": 2});
+        }
+    );
+    it("Returns falsy CheckerResponse when statements charges are unbalanced",
+        () => {
+            // Arrange
+            const chargedIon: Ion = structuredClone(augmentedIon);
+            chargedIon.molecules = [[structuredClone(element), 1]];
+
+            const chargedTerm: Term = augmentNode(structuredClone(term));
+            chargedTerm.value = chargedIon;
+
+            const chargedExpr: Expression = structuredClone(augmentedExpression);
+            chargedExpr.terms?.push(chargedTerm);
+
             const unbalancedCharges: Statement = augmentNode(structuredClone(statement));
             unbalancedCharges.left = structuredClone(chargedExpr);
 
+            // Act
+            const unbalancedCheck = unaugmentedTestCheck(unbalancedCharges, unbalancedCharges, { keepAggregates: true});
+
             // Assert
-            expect(unaugmentedTestCheck(balancedCharges, unbalancedCharges).isChargeBalanced).toBeTruthy();
-            expect(unaugmentedTestCheck(unbalancedCharges, balancedCharges).isChargeBalanced).toBeFalsy();
+            expect(unbalancedCheck.isEqual).toBeFalsy();
+            expect(unbalancedCheck.isChargeBalanced).toBeFalsy();
+            expect(unbalancedCheck.chargeCount).toEqual({"numerator": 3, "denominator": 2});
         }
     );
 });
@@ -694,7 +830,7 @@ describe("testCheck Statement", () => {
 describe("Check", () => {
     it("Returns error message when given one",
         () => {
-            // Act
+            // Arrange
             const error: ParseError = {
                 type: "error",
                 value: "Sphinx of black quartz, judge my vow",
@@ -705,21 +841,25 @@ describe("Check", () => {
                 result: error
             }
 
+            // Act
             const response: CheckerResponse = check(errorAST, ast, options);
+
             // Assert
             expect(response.containsError).toBeTruthy();
             expect(response.error).toBe("Sphinx of black quartz, judge my vow");
             expect(response.expectedType).toBe("statement");
         }
     );
-    it("Returns type mismatch when appropriate",
+    it("Returns type mismatch when types are different",
         () => {
-            // Act
+            // Arrange
             const expressionAST: ChemAST = {
                 result: structuredClone(expression)
             }
 
+            // Act
             const response: CheckerResponse = check(ast, expressionAST, options);
+
             // Assert
             expect(response.typeMismatch).toBeTruthy();
             expect(response.expectedType).toBe("expr");

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -462,7 +462,7 @@ describe("testCheck Term", () => {
             // Arrange
             const stateTerm = structuredClone(term);
             stateTerm.state = "(aq)";
-            let stateTermCopy: Term = structuredClone(stateTerm);
+            const stateTermCopy: Term = structuredClone(stateTerm);
 
             // Act
             const testResponse = testCheck(stateTerm, stateTermCopy)
@@ -685,6 +685,14 @@ describe("testCheck Expression", () => {
 });
 
 describe("testCheck Statement", () => {
+    const chargedIon: Ion = structuredClone(augmentedIon);
+    chargedIon.molecules = [[structuredClone(element), 1]];
+
+    const chargedTerm: Term = augmentNode(structuredClone(term));
+    chargedTerm.value = chargedIon;
+
+    const chargedExpr: Expression = structuredClone(augmentedExpression);
+    chargedExpr.terms?.push(chargedTerm);
     it("Returns truthy CheckerResponse when expressions match",
         () => {
             // Arrange
@@ -779,15 +787,6 @@ describe("testCheck Statement", () => {
     it("Returns truthy CheckerResponse when statements charges are balanced", 
         () => {
             // Arrange
-            const chargedIon: Ion = structuredClone(augmentedIon);
-            chargedIon.molecules = [[structuredClone(element), 1]];
-
-            const chargedTerm: Term = augmentNode(structuredClone(term));
-            chargedTerm.value = chargedIon;
-
-            const chargedExpr: Expression = structuredClone(augmentedExpression);
-            chargedExpr.terms?.push(chargedTerm);
-
             const balancedCharges: Statement = augmentNode(structuredClone(statement));
             balancedCharges.left = structuredClone(chargedExpr);
             balancedCharges.right = structuredClone(chargedExpr);
@@ -804,15 +803,6 @@ describe("testCheck Statement", () => {
     it("Returns falsy CheckerResponse when statements charges are unbalanced",
         () => {
             // Arrange
-            const chargedIon: Ion = structuredClone(augmentedIon);
-            chargedIon.molecules = [[structuredClone(element), 1]];
-
-            const chargedTerm: Term = augmentNode(structuredClone(term));
-            chargedTerm.value = chargedIon;
-
-            const chargedExpr: Expression = structuredClone(augmentedExpression);
-            chargedExpr.terms?.push(chargedTerm);
-
             const unbalancedCharges: Statement = augmentNode(structuredClone(statement));
             unbalancedCharges.left = structuredClone(chargedExpr);
 

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -1,4 +1,3 @@
-import exp from "constants";
 import { Bracket, Compound, Element, exportedForTesting, Ion, Term, Expression, Statement, ParseError, check, ChemAST, augment, STARTING_COEFFICIENT, Result, ASTNode, isExpression } from "../../src/models/Chemistry";
 import { CheckerResponse, listComparison, ChemistryOptions } from "../../src/models/common";
 const { augmentNode } = exportedForTesting;
@@ -139,7 +138,7 @@ function testCheck<T extends ASTNode>(target: T, test: T, options?: ChemistryOpt
 }
 
 function unaugmentedTestCheck<T extends ASTNode>(target: T, test: T, options?: ChemistryOptions): CheckerResponse {
-    return check({result: target as unknown as Result}, {result: test as unknown as Result}, options ?? {});
+    return check(structuredClone({result: target as unknown as Result}), structuredClone({result: test as unknown as Result}), options ?? {});
 }
 
 describe("listComparison", () => {
@@ -277,7 +276,7 @@ describe("testCheck Compounds", () => {
             const compoundCopy: Compound = structuredClone(compound);
 
             // Act
-            const testResponse = testCheck(compoundCopy, structuredClone(compound), { keepAggregates: true });
+            const testResponse = testCheck(compound, compoundCopy, { keepAggregates: true });
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -297,7 +296,7 @@ describe("testCheck Compounds", () => {
             const permutationsOptions = { allowPermutations: true };
 
             // Act
-            const testResponse = testCheck(permutedCompound, structuredClone(compound), permutationsOptions);
+            const testResponse = testCheck(permutedCompound, compound, permutationsOptions);
             const hydrocarbonResponse = testCheck(hydrocarbonCompound, permutedHydrocarbonCompound, permutationsOptions);
 
             // Assert
@@ -314,8 +313,8 @@ describe("testCheck Compounds", () => {
             lengthMismatch.elements?.push(structuredClone(element));
 
             // Act
-            const typesIncorrect = unaugmentedTestCheck(typeMismatch, augmentNode(structuredClone(compound)));
-            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentNode(structuredClone(compound)));
+            const typesIncorrect = unaugmentedTestCheck(typeMismatch, augmentedCompound);
+            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedCompound);
 
             // Assert
             expect(typesIncorrect.isEqual).toBeFalsy();
@@ -341,8 +340,8 @@ describe("testCheck Compounds", () => {
             elementMismatch.elements = [elementCoeffMismatch];
 
             // Act
-            const bracketResponse: CheckerResponse = testCheck(bracketCoeffMismatch, structuredClone(bracket));
-            const elementResponse: CheckerResponse = testCheck(elementCoeffMismatch, structuredClone(element));
+            const bracketResponse: CheckerResponse = testCheck(bracketCoeffMismatch, bracket);
+            const elementResponse: CheckerResponse = testCheck(elementCoeffMismatch, element);
 
             // Assert
             expect(testCheck(bracketMismatch, minimalBracketCompound)).toEqual({...bracketResponse, expectedType: "compound", receivedType: "compound"});
@@ -352,7 +351,7 @@ describe("testCheck Compounds", () => {
     it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            const testResponse = unaugmentedTestCheck(structuredClone(compound), augmentedCompound, { keepAggregates: true });
+            const testResponse = unaugmentedTestCheck(compound, augmentedCompound, { keepAggregates: true });
             
             // Assert
             expect(testResponse.containsError).toBeTruthy();
@@ -370,7 +369,7 @@ describe("testCheck Ions", () => {
             const ionClone: Ion = structuredClone(ion);
 
             // Act
-            const testResponse = testCheck(structuredClone(ion), ionClone, { keepAggregates: true });
+            const testResponse = testCheck(ion, ionClone, { keepAggregates: true });
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -389,7 +388,7 @@ describe("testCheck Ions", () => {
             const permutationsOptions = { allowPermutations: true, keepAggregates: true };
 
             // Act
-            const testResponse = testCheck(permutedIon, structuredClone(ion), permutationsOptions);
+            const testResponse = testCheck(permutedIon, ion, permutationsOptions);
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -405,7 +404,7 @@ describe("testCheck Ions", () => {
             }
 
             // Act
-            const moleculeIncorrect = unaugmentedTestCheck(moleculeMismatch, structuredClone(augmentedIon), { keepAggregates: true });
+            const moleculeIncorrect = unaugmentedTestCheck(moleculeMismatch, augmentedIon, { keepAggregates: true });
 
             // Assert
             expect(moleculeIncorrect.isEqual).toBeFalsy();
@@ -422,7 +421,7 @@ describe("testCheck Ions", () => {
             }
 
             // Act
-            const chargeIncorrect = unaugmentedTestCheck(chargeMismatch, structuredClone(augmentedIon), { keepAggregates: true });
+            const chargeIncorrect = unaugmentedTestCheck(chargeMismatch, augmentedIon, { keepAggregates: true });
 
             // Assert
             expect(chargeIncorrect.isEqual).toBeFalsy();
@@ -436,7 +435,7 @@ describe("testCheck Ions", () => {
             lengthMismatch.molecules?.push([structuredClone(element), 1]);
 
             // Act
-            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, structuredClone(augmentedIon), { keepAggregates: true});
+            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedIon, { keepAggregates: true});
 
             // Assert
             expect(lengthIncorrect.isEqual).toBeFalsy();
@@ -445,7 +444,7 @@ describe("testCheck Ions", () => {
     it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            const testResponse = unaugmentedTestCheck(structuredClone(ion), augmentedIon);
+            const testResponse = unaugmentedTestCheck(ion, augmentedIon);
 
             // Assert
             expect(testResponse.containsError).toBeTruthy();
@@ -511,7 +510,7 @@ describe("testCheck Term", () => {
             perturbedTerm.coeff = { numerator: 6, denominator: 4 };
 
             // Act
-            const testResponse = testCheck(perturbedTerm, structuredClone(term), scaledOptions);
+            const testResponse = testCheck(perturbedTerm, term, scaledOptions);
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -525,7 +524,7 @@ describe("testCheck Term", () => {
             mismatchTerm.coeff = { numerator: 1, denominator: 5 };
 
             // Act
-            const testResponse = testCheck(mismatchTerm, structuredClone(term));
+            const testResponse = testCheck(mismatchTerm, term);
 
             // Assert
             expect(testResponse.isEqual).toBeFalsy();
@@ -576,7 +575,7 @@ describe("testCheck Term", () => {
             mismatchTerm.value = { type: "electron" };
 
             // Act
-            const testResponse = testCheck(mismatchTerm, structuredClone(term));
+            const testResponse = testCheck(mismatchTerm, term);
 
             // Assert
             expect(testResponse.isEqual).toBeFalsy();
@@ -590,8 +589,8 @@ describe("testCheck Term", () => {
             complexTerm.value = structuredClone(compound);
 
             // Act
-            const testResponse = testCheck(complexTerm, structuredClone(term));
-            const compoundResponse = testCheck(structuredClone(compound), minimalCompound);
+            const testResponse = testCheck(complexTerm, term);
+            const compoundResponse = testCheck(compound, minimalCompound);
 
             // Assert
             expect(testResponse).toEqual({...compoundResponse, expectedType: "term", receivedType: "term"});
@@ -627,7 +626,7 @@ describe("testCheck Expression", () => {
             }
 
             // Act
-            const testResponse = unaugmentedTestCheck(perturbedExpression, structuredClone(augmentedExpression), scaledOptions);
+            const testResponse = unaugmentedTestCheck(perturbedExpression, augmentedExpression, scaledOptions);
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -673,7 +672,7 @@ describe("testCheck Expression", () => {
     it("Returns an error if the AST is not augmented",
         () => {
             // Act
-            const testResponse = unaugmentedTestCheck(structuredClone(expression), augmentedExpression);
+            const testResponse = unaugmentedTestCheck(expression, augmentedExpression);
 
             // Assert
             expect(testResponse.containsError).toBeTruthy();
@@ -698,13 +697,12 @@ describe("testCheck Statement", () => {
             // Arrange
             const copy: Statement = structuredClone(statement);
 
-            const copyResult: CheckerResponse = testCheck(copy, statement);
-
-            copy.arrow = "DArr";
             const doubleArrowCopy: Statement = structuredClone(copy);
+            doubleArrowCopy.arrow = "DArr";
 
             // Act
-            const arrowResult = testCheck(copy, doubleArrowCopy);
+            const copyResult: CheckerResponse = testCheck(copy, statement, { keepAggregates: true });
+            const arrowResult: CheckerResponse = testCheck(doubleArrowCopy, doubleArrowCopy, { keepAggregates: true });
 
             // Assert
             expect(copyResult.isEqual).toBeTruthy();
@@ -728,7 +726,7 @@ describe("testCheck Statement", () => {
             }
 
             // Act
-            const testResponse = unaugmentedTestCheck(perturbedStatement, structuredClone(augmentedStatement), scaledOptions);
+            const testResponse = unaugmentedTestCheck(perturbedStatement, augmentedStatement, scaledOptions);
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
@@ -787,7 +785,7 @@ describe("testCheck Statement", () => {
     it("Returns truthy CheckerResponse when statements charges are balanced", 
         () => {
             // Arrange
-            const balancedCharges: Statement = augmentNode(structuredClone(statement));
+            const balancedCharges: Statement = structuredClone(augmentedStatement);
             balancedCharges.left = structuredClone(chargedExpr);
             balancedCharges.right = structuredClone(chargedExpr);
 
@@ -803,7 +801,7 @@ describe("testCheck Statement", () => {
     it("Returns falsy CheckerResponse when statements charges are unbalanced",
         () => {
             // Arrange
-            const unbalancedCharges: Statement = augmentNode(structuredClone(statement));
+            const unbalancedCharges: Statement = structuredClone(augmentedStatement);
             unbalancedCharges.left = structuredClone(chargedExpr);
 
             // Act

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -304,20 +304,29 @@ describe("testCheck Compounds", () => {
             expect(hydrocarbonResponse.isEqual).toBeTruthy();
         }
     );
-    it("Returns falsy CheckerResponse when compounds don't match",
+    it("Returns falsy CheckerResponse when compounds have mismatched type",
         () => {
             // Arrange
             const typeMismatch: Compound = structuredClone(compound);
             typeMismatch.elements = [structuredClone(element), structuredClone(element)];
+
+            // Act
+            const typesIncorrect = unaugmentedTestCheck(typeMismatch, augmentedCompound);
+
+            // Assert
+            expect(typesIncorrect.isEqual).toBeFalsy();
+        }
+    );
+    it("Returns falsy CheckerResponse when compounds have mismatched length",
+        () => {
+            // Arrange
             const lengthMismatch: Compound = augmentNode(structuredClone(compound));
             lengthMismatch.elements?.push(structuredClone(element));
 
             // Act
-            const typesIncorrect = unaugmentedTestCheck(typeMismatch, augmentedCompound);
             const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedCompound);
 
             // Assert
-            expect(typesIncorrect.isEqual).toBeFalsy();
             expect(lengthIncorrect.isEqual).toBeFalsy();
         }
     );
@@ -579,7 +588,7 @@ describe("testCheck Term", () => {
 
             // Assert
             expect(testResponse.isEqual).toBeFalsy();
-            expect(testResponse.typeMismatch).toBeFalsy();
+            expect(testResponse.typeMismatch).toBeTruthy();
         }
     )
     it("Retains CheckerResponse properties",
@@ -633,22 +642,30 @@ describe("testCheck Expression", () => {
             expect(testResponse.atomCount?.O).toEqual({"numerator": 4, "denominator": 1});
         }
     );
-    it("Returns falsy CheckerResponse when expressions don't match",
+    it("Returns falsy CheckerResponse when expressions have mismatched terms",
+        () => {
+            // Arrange
+            const termMismatch: Expression = structuredClone(augmentedExpression);
+            if (termMismatch.terms) termMismatch.terms[1] = structuredClone(hydrate);
+
+            // Act
+            const termIncorrect = unaugmentedTestCheck(termMismatch, augmentedExpression);
+
+            // Assert
+            expect(termIncorrect.isEqual).toBeFalsy();
+        }
+    );
+    it("Returns falsy CheckerResponse when expressions have mismatched length",
         () => {
             // Arrange
             const lengthMismatch: Expression = structuredClone(augmentedExpression);
             lengthMismatch.terms?.push(structuredClone(hydrate));
 
-            const termMismatch: Expression = structuredClone(augmentedExpression);
-            if (termMismatch.terms) termMismatch.terms[1] = structuredClone(hydrate);
-
             // Act
             const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedExpression);
-            const termIncorrect = unaugmentedTestCheck(termMismatch, augmentedExpression);
 
             // Assert
             expect(lengthIncorrect.isEqual).toBeFalsy();
-            expect(termIncorrect.isEqual).toBeFalsy();
         }
     );
     it("Retains CheckerResponse properties",

--- a/test/models/Chemistry.test.ts
+++ b/test/models/Chemistry.test.ts
@@ -398,7 +398,7 @@ describe("testCheck Ions", () => {
             expect(moleculeIncorrect.typeMismatch).toBeFalsy();
             expect(moleculeIncorrect.termAtomCount?.Cl).toBe(1);
             expect(chargeIncorrect.isEqual).toBeFalsy();
-            expect(chargeIncorrect.termChargeCount).toBe(-1);
+            expect(chargeIncorrect.termChargeCount).toBe(-2);
             expect(lengthIncorrect.isEqual).toBeFalsy();
         }
     );

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -149,7 +149,7 @@ describe("testCheck Isotope", () => {
             expect(testResponse.validAtomicNumber).toBeTruthy();
         }
     );
-    it("Returns falsy CheckerResponse when isotope do not match",
+    it("Returns falsy CheckerResponse when isotope don't match",
         () => {
             // Arrange
             const elementMismatch: Isotope = structuredClone(isotope);
@@ -254,21 +254,29 @@ describe("testCheck Expression", () => {
             expect(testResponse.isEqual).toBeTruthy();
         }
     );
-    it("Returns falsy CheckerResponse when expressions do not match",
+    it("Returns falsy CheckerResponse when expressions have mismatched length",
         () => {
             // Arrange
             const lengthMismatch: Expression = structuredClone(augmentedExpression);
             lengthMismatch.terms?.push(structuredClone(term))
 
+            // Act
+            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedExpression);
+
+            // Assert
+            expect(lengthIncorrect.isEqual).toBeFalsy();
+        }
+    );
+    it("Returns falsy CheckerResponse when expressions have mismatched terms",
+        () => {
+            // Arrange
             const termMismatch: Expression = structuredClone(augmentedExpression);
             if (termMismatch.terms) termMismatch.terms[1] = structuredClone(particleTerm);
 
             // Act
-            const lengthIncorrect = unaugmentedTestCheck(lengthMismatch, augmentedExpression);
             const termIncorrect = unaugmentedTestCheck(termMismatch, augmentedExpression);
 
             // Assert
-            expect(lengthIncorrect.isEqual).toBeFalsy();
             expect(termIncorrect.isEqual).toBeFalsy();
         }
     );
@@ -299,7 +307,7 @@ describe("testCheck Statement", () => {
             expect(copyResult.isEqual).toBeTruthy();
         }
     );
-    it("Returns falsy CheckerResponse when expressions do not match",
+    it("Returns falsy CheckerResponse when expressions don't match",
         () => {
             // Arrange
             const swappedExpressions: Statement = structuredClone(statement);
@@ -329,7 +337,7 @@ describe("testCheck Statement", () => {
             expect(balancedResponse.balancedMass).toBeTruthy();
         }
     )
-    it("Returns falsy CheckerResponse when expressions are balanced",
+    it("Returns falsy CheckerResponse when expressions are unbalanced",
         () => {
             // Arrange
             const balancedStatement: Statement = structuredClone(statement);

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -1,6 +1,5 @@
-import { iteratee } from "lodash";
 import { Particle, Isotope, Term, Expression, Statement, ParseError, check, NuclearAST, exportedForTesting } from "../../src/models/Nuclear";
-import { ChemicalSymbol, CheckerResponse, listComparison } from "../../src/models/common";
+import { CheckerResponse } from "../../src/models/common";
 const { checkNodesEqual } = exportedForTesting;
 
 const original = console.error;
@@ -20,29 +19,29 @@ const response: CheckerResponse = {
     containsError: false,
     error: { message: "" },
     expectedType: "statement",
+    receivedType: "statement",
     typeMismatch: false,
     sameState: true,
     sameCoefficient: true,
+    sameElements: true,
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
-    receivedType: "statement",
-    allowPermutations: false
-};
+}
 // Alternative response object
 const newResponse: CheckerResponse = {
     containsError: false,
     error: { message: "" },
-    expectedType: "unknown",
+    expectedType: "statement",
+    receivedType: "statement",
     typeMismatch: false,
-    sameState: false,
-    sameCoefficient: false,
+    sameState: true,
+    sameCoefficient: true,
+    sameElements: true,
     isBalanced: true,
     isEqual: true,
     isNuclear: true,
-    receivedType: "unknown",
-    allowPermutations: false
-};
+}
 
 const trueResponse: CheckerResponse = structuredClone(response);
 trueResponse.balancedAtom = true;

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -255,7 +255,7 @@ describe("CheckNodesEqual Expression", () => {
             // Assert
             expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).containsError).toBeTruthy();
             expect(checkNodesEqual(unaugmentedExpression, expression, structuredClone(response)).error).toEqual(
-                { message: "Received unaugmenttened AST during checking process." }
+                { message: "Received unaugmented AST during checking process." }
             );
 
             expect(console.error).toHaveBeenCalled();

--- a/test/models/Nuclear.test.ts
+++ b/test/models/Nuclear.test.ts
@@ -88,9 +88,10 @@ function unaugmentedTestCheck<T extends ASTNode>(target: T, test: T): CheckerRes
 describe("testCheck Particle", () => {
     it("Returns truthy CheckerResponse when particles match",
         () => {
-            // Act
+            // Arrange
             const particleCopy: Particle = structuredClone(particle)
 
+            // Act
             const testResponse = testCheck(particleCopy, particle);
 
             // Assert
@@ -100,12 +101,13 @@ describe("testCheck Particle", () => {
     );
     it("Returns falsy CheckerResponse when particles don't match",
         () => {
-            // Act
+            // Arrange
             const valueMismatch: Particle = structuredClone(particle);
             valueMismatch.particle = "betaparticle";
             valueMismatch.mass = 0;
             valueMismatch.atomic = -1;
 
+            // Act
             const elementIncorrect = testCheck(valueMismatch, particle);
 
             // Assert
@@ -115,10 +117,11 @@ describe("testCheck Particle", () => {
     );
     it("Returns falsy CheckerResponse when atomic number is invalid",
         () => {
-            // Act
+            // Arrange
             const nucleonMismatch: Particle = structuredClone(particle);
             nucleonMismatch.particle = "betaparticle";
 
+            // Act
             const nucleonIncorrect = testCheck(nucleonMismatch, particle);
 
             // Assert
@@ -131,9 +134,10 @@ describe("testCheck Particle", () => {
 describe("testCheck Isotope", () => {
     it("Returns truthy CheckerResponse when isotope match",
         () => {
-            // Act
+            // Arrange
             const isotopeCopy: Isotope = structuredClone(isotope);
 
+            // Act
             const testResponse = testCheck(isotopeCopy, isotope);
 
             // Assert
@@ -143,11 +147,13 @@ describe("testCheck Isotope", () => {
     );
     it("Returns falsy CheckerResponse when isotope do not match",
         () => {
+            // Arrange
             const elementMismatch: Isotope = structuredClone(isotope);
             elementMismatch.element = "Cl";
             elementMismatch.mass = 35;
             elementMismatch.atomic = 17;
 
+            // Act
             const elementIncorrect = testCheck(elementMismatch, isotope);
 
             // Assert
@@ -157,9 +163,11 @@ describe("testCheck Isotope", () => {
     );
     it("Returns falsy CheckerResponse when atomic number is invalid",
         () => {
+            // Arrange
             const nucleonMismatch: Isotope = structuredClone(isotope);
             nucleonMismatch.element = "Cl";
 
+            // Act
             const nucleonIncorrect = testCheck(nucleonMismatch, isotope);
 
             // Assert
@@ -172,23 +180,32 @@ describe("testCheck Isotope", () => {
 describe("testCheck Term", () => {
     it("Returns truthy CheckerResponse when terms match",
         () => {
-            let termCopy: Term = structuredClone(term);
+            // Arrange
+            const termCopy: Term = structuredClone(term);
 
-            let testResponse = testCheck(termCopy, term)
+            // Act
+            const testResponse = testCheck(termCopy, term)
+
+            // Assert
             expect(testResponse.isEqual).toBeTruthy();
         }
     );
     it("Returns falsy CheckerResponse when terms don't match",
         () => {
-            // Mismatched coefficients
-            let mismatchTerm: Term = structuredClone(term);
+            // Arrange
+            const mismatchTerm: Term = structuredClone(term);
             mismatchTerm.coeff = 3;
 
-            expect(testCheck(mismatchTerm, term).isEqual).toBeFalsy();
-            expect(testCheck(mismatchTerm, term).sameCoefficient).toBeFalsy();
+            // Act
+            const termIncorrect = testCheck(mismatchTerm, term);
+            const typeIncorrect = testCheck(particleTerm, term);
+
+            // Assert
+            expect(termIncorrect.isEqual).toBeFalsy();
+            expect(termIncorrect.sameCoefficient).toBeFalsy();
 
             // Mismatched type
-            expect(testCheck(particleTerm, term).isEqual).toBeFalsy();
+            expect(typeIncorrect.isEqual).toBeFalsy();
         }
     );
     it("Retains CheckerResponse properties",
@@ -205,6 +222,7 @@ describe("testCheck Term", () => {
             const particleCopyTerm: Term = structuredClone(particleTerm);
             particleCopyTerm.value = particleCopy;
 
+            // Act
             const isotopeResponse = testCheck(isotopeError, isotope);
             const particleResponse = testCheck(particleCopy, particle);
 
@@ -221,32 +239,38 @@ describe("testCheck Term", () => {
 describe("testCheck Expression", () => {
     it("Returns truthy CheckerResponse when expressions match",
         () => {
-            // Act
+            // Arrange
             const permutedExpression: Expression = structuredClone(expression);
             permutedExpression.terms?.reverse;
 
+            // Act
             const testResponse: CheckerResponse = testCheck(permutedExpression, expression);
+
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
         }
     );
     it("Returns falsy CheckerResponse when expressions do not match",
         () => {
-            // Act
+            // Arrange
             const lengthMismatch: Expression = structuredClone(expression);
             lengthMismatch.terms?.push(structuredClone(term));
 
             const termMismatch: Expression = structuredClone(expression);
             if (termMismatch.terms) termMismatch.terms[1] = structuredClone(term);
 
+            // Act
+            const lengthIncorrect = testCheck(lengthMismatch, expression);
+            const termIncorrect = testCheck(termMismatch, expression);
+
             // Assert
-            expect(testCheck(lengthMismatch, expression).isEqual).toBeFalsy();
-            expect(testCheck(termMismatch, expression).isEqual).toBeFalsy();
+            expect(lengthIncorrect.isEqual).toBeFalsy();
+            expect(termIncorrect.isEqual).toBeFalsy();
         }
     );
     it("Returns an error if the AST is not augmented",
         () => {
-            // Act
+            // Arrange
             // This is the same as expression just unaugmented
             const unaugmentedExpression: Expression = {
                 type: "expr",
@@ -254,9 +278,12 @@ describe("testCheck Expression", () => {
                 rest: structuredClone(particleTerm)
             }
 
+            // Act
+            const testResponse = unaugmentedTestCheck(unaugmentedExpression, expression);
+
             // Assert
-            expect(unaugmentedTestCheck(unaugmentedExpression, expression).containsError).toBeTruthy();
-            expect(unaugmentedTestCheck(unaugmentedExpression, expression).error).toEqual("Received unaugmented AST during checking process.");
+            expect(testResponse.containsError).toBeTruthy();
+            expect(testResponse.error).toEqual("Received unaugmented AST during checking process.");
 
             expect(console.error).toHaveBeenCalled();
         }
@@ -266,9 +293,10 @@ describe("testCheck Expression", () => {
 describe("testCheck Statement", () => {
     it("Returns truthy CheckerResponse when expressions match",
         () => {
-            // Act
+            // Arrange
             const copy: Statement = structuredClone(statement);
 
+            // Act
             const copyResult: CheckerResponse = testCheck(copy, statement);
 
             // Assert
@@ -277,12 +305,13 @@ describe("testCheck Statement", () => {
     );
     it("Returns falsy CheckerResponse when expressions do not match",
         () => {
-            // Act
+            // Arrange
             const swappedExpressions: Statement = structuredClone(statement);
             const tempExpression = swappedExpressions.left;
             swappedExpressions.left = swappedExpressions.right;
             swappedExpressions.right = tempExpression;
 
+            // Act
             const swapResult = testCheck(swappedExpressions, statement);
 
             // Assert
@@ -323,7 +352,7 @@ describe("Check", () => {
 
     it("Returns error message when given one",
         () => {
-            // Act
+            // Arrange
             const error: ParseError = {
                 type: "error",
                 value: "Sphinx of black quartz, judge my vow",
@@ -334,7 +363,9 @@ describe("Check", () => {
                 result: error
             }
 
+            // Act
             const response: CheckerResponse = check(errorAST, ast);
+
             // Assert
             expect(response.containsError).toBeTruthy();
             expect(response.error).toBe("Sphinx of black quartz, judge my vow");
@@ -343,12 +374,14 @@ describe("Check", () => {
     );
     it("Returns type mismatch when appropriate",
         () => {
-            // Act
+            // Arrange
             const expressionAST: NuclearAST = {
                 result: structuredClone(expression)
             }
 
+            // Act
             const response: CheckerResponse = check(ast, expressionAST);
+
             // Assert
             expect(response.typeMismatch).toBeTruthy();
             expect(response.expectedType).toBe("expr");


### PR DESCRIPTION
The Chemistry Checker has many small parts existing at many different levels. This means that unit tests are incredibly useful for checking each property (although also rather tedious to write).

The checker as a whole is quite notably different from how I inherited it, so I've needed to fix and restructure all old tests, as well as add new tests for new features (e.g. allowScalingCoefficients) and separate several old tests into multiple smaller parts for consistency/clearer testing.

The tests are all passing with behaviour I expect, so this shouldn't need _much_ checking, but there's also plenty of code so it's reasonably likely I did miss something.
 
---

~~I've merged in the [Linear Comparison](https://github.com/isaacphysics/chemistry-checker-js/pull/10) branch for this to make sure it passes all tests (one had to be changed to reflect its new typeMismatch behaviour). In the off-chance this is merged in before that is, we should undo that merge commit first so it can be looked at separately.~~