### PR TITLE
Set sameHydrate to true by default

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -121,6 +121,7 @@ const STARTING_RESPONSE: (options?: ChemistryOptions, coefficientScalingValue?: 
     isEqual: true,
     typeMismatch: false,
     sameCoefficient: true,
+    sameHydrate: true,
     sameElements: true,
     sameState: true,
     sameCharge: true,
@@ -426,7 +427,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             const comparator = (test: [Molecule, number], target: [Molecule, number], response: CheckerResponse): CheckerResponse => {
                 const newResponse = checkNodesEqual(test[0], target[0], response);
                 newResponse.sameCharge = newResponse.sameCharge && test[1] === target[1];
-                newResponse.isEqual = newResponse.isEqual && (newResponse.sameCharge === true);
+                newResponse.isEqual = newResponse.isEqual && (newResponse.sameCharge ?? true);
                 
                 if (!test[0].bracketed) {
                     // If not bracketed, add the charge directly to the chargeCount of the term
@@ -609,7 +610,7 @@ export function check(test: ChemAST, target: ChemAST, options: ChemistryOptions)
 
     let newResponse = checkNodesEqual(test.result, target.result, response);
     // We set flags for these properties in checkNodesEqual, but we only apply the isEqual check here due to listComparison
-    newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && (newResponse.sameState === true) && (newResponse.sameBrackets === true) && (newResponse.sameHydrate === true);
+    newResponse.isEqual = newResponse.isEqual && newResponse.sameCoefficient && (newResponse.sameState ?? true) && (newResponse.sameBrackets ?? true) && (newResponse.sameHydrate ?? true);
 
     if (!newResponse.options?.keepAggregates) {
         newResponse = removeAggregates(newResponse);

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -198,7 +198,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
             return response;
         }
 
-        response.validAtomicNumber = (response.validAtomicNumber === true) && isValidAtomicNumber(test);
+        response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
         response.sameElements = response.sameElements && checkParticlesEqual(test, target);
         response.isEqual = response.isEqual && response.sameElements && response.validAtomicNumber;
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -61,6 +61,8 @@ export function mergeResponses(response1: CheckerResponse, response2: CheckerRes
     newResponse.sameCoefficient = response1.sameCoefficient && response2.sameCoefficient;
     newResponse.sameElements = response1.sameElements && response2.sameElements;
     if (!response1.isNuclear) {
+        newResponse.sameCharge = response1.sameCharge && response2.sameCharge;
+        newResponse.sameHydrate = response1.sameHydrate && response2.sameHydrate;
         newResponse.sameState = response1.sameState && response2.sameState;
         newResponse.sameBrackets = response1.sameBrackets && response2.sameBrackets;
     } else {


### PR DESCRIPTION
The main problem actually causing problems here was that `sameHydrate` wasn't set to `true` by default. 

This would've been caught by line 613 when using the `??` nullish operator rather than the `===` equality operator except I very recently changed it, so I've switched back to `??` to avoid any possible future issues.

We also weren't seeing it in the logs because it wasn't being recorded properly, so I've changed that too.