### PR TITLE
Add linear comparison for non-permuting arrays

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -566,6 +566,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         return finalResponse;
     } else {
         // There was a type mismatch
+        response.typeMismatch = true;
         response.isEqual = false;
         // We must still check the children of the node to get complete aggregate counts
         if (test.type == "error") {

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -84,18 +84,37 @@ export function removeAggregates(response: CheckerResponse): CheckerResponse {
     return response;
 }
 
+export function linearComparison<T>(
+    testList: T[],
+    targetList: T[],
+    response: CheckerResponse,
+    comparator: (test: T, target: T, response: CheckerResponse) => CheckerResponse
+): CheckerResponse {
+    let possibleResponse = structuredClone(response);
+
+    if (testList.length !== targetList.length) {
+        possibleResponse.sameElements = false;
+        possibleResponse.isEqual = false;
+        return possibleResponse;
+    }
+
+    for (let i = 0; i < testList.length; i++) {
+        possibleResponse = comparator(testList[i], targetList[i], structuredClone(possibleResponse));
+    }
+
+    return possibleResponse;
+}
+
 export function listComparison<T>(
     testList: T[],
     targetList: T[],
     response: CheckerResponse,
     comparator: (test: T, target: T, response: CheckerResponse) => CheckerResponse
 ): CheckerResponse {
-    // TODO: look at a more efficient method of comparison
     const indices: number[] = []; // the indices on which a match was made
     let possibleResponse = structuredClone(response);
 
     // Get aggregates
-    // TODO: discuss and see if a better solution exists
     let aggregatesResponse = structuredClone(response);
     for (let item of testList) {
         // This will always pass, this is to get the accurate aggregate bookkeeping values


### PR DESCRIPTION
`listComparison` checks all permutations of entries in two arrays until it finds a match. This may make it skip over a close (but not entirely accurate) match, so give more generic feedback (typically our "Wrong Elements" feedback `"Check that you have all the correct atoms present and in the right place!"`)

For questions not allowing permuted elements (like all currently published ones), we can instead use `linearComparison` to linearly check the elements in the two arrays. I hadn't done this before as it may lead to an element mismatch being classified as a generic type mismatch (which is notably NOT a full expression type mismatch), however I've now updated the API so a generic type mismatch causes feedback to also be generic - so this is fine.

This is probably best explained with an example:

## Expected Answer
`Cu(H2O)4(OH)2`

## Received Answer
| Received Answer | Previous Feedback | New Feedback |
| --- | --- | --- |
| Cu(H2O)4[OH]2 | Wrong Elements | Wrong Brackets |
| Cu(H2O)4(OH)2 (s) | Wrong Elements | Wrong State |
| Cu(H2O)4(OH)2^{3+} | Wrong Elements | _none/generic (type mismatch)_ |
| Cu(OH2)4(OH)2 | Wrong Elements | Wrong Elements |
| (OH)2Cu(H2O)4 | Wrong Elements | _none/generic (type mismatch)_ |

For the first three cases, we prefer the new feedback. For the fourth or fifth case, we are happy with either the previous or the new feedback - so it's an overall improvement.
