### PR TITLE
Fix electron representations

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -464,7 +464,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
     }
     else if (isElectron(test) && isElectron(target)) {
         // Electrons have no properties to test equivalence of, but charge must still be aggregated
-        response.termChargeCount = (response.termChargeCount ?? 0) + 1;
+        response.termChargeCount = (response.termChargeCount ?? 0) - 1;
 
         return response;
     }

--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -463,7 +463,9 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         }
     }
     else if (isElectron(test) && isElectron(target)) {
-        // There is no need to check electrons, they are always equal
+        // Electrons have no properties to test equivalence of, but charge must still be aggregated
+        response.termChargeCount = (response.termChargeCount ?? 0) + 1;
+
         return response;
     }
     else if (isTerm(test) && isTerm(target)) {

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -190,13 +190,9 @@ const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (opti
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isParticle(test) && isParticle(target)) {
-        // Answers can be entered without a mass or atomic number. However, this is always wrong so we throw an error
-        if (test.mass === null || test.atomic === null) {
-            response.containsError = true;
-            response.error = "Check that all atoms have a mass and atomic number!"
-            response.isEqual = false;
-            return response;
-        }
+        // Answers can be entered without a mass or atomic number. Some particles e.g. electrons can be validly represented this way so a conversion is made
+        if (test.mass === null) test.mass = 0;
+        if (test.atomic === null) test.atomic = 0;
 
         response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
         response.sameElements = response.sameElements && checkParticlesEqual(test, target);
@@ -214,7 +210,7 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         return response;
     } else if (isIsotope(test) && isIsotope(target)) {
-        // Answers can be entered without a mass or atomic number. However, this is always wrong so we throw an error
+        // Answers can be entered without a mass or atomic number. However, this is always wrong for isotopes so we throw an error
         if (test.mass === null || test.atomic === null) {
             response.containsError = true;
             response.error = "Check that all atoms have a mass and atomic number!"

--- a/src/models/Nuclear.ts
+++ b/src/models/Nuclear.ts
@@ -130,40 +130,24 @@ export function augment(ast: NuclearAST): NuclearAST {
     }
 }
 
+const particleMassAtomic: { [key in ParticleString]: [number, number] } = {
+    alphaparticle: [4, 2],
+    betaparticle: [0, -1],
+    gammaray: [0, 0],
+    neutrino: [0, 0],
+    antineutrino: [0, 0],
+    electron: [0, -1],
+    positron: [0, 1],
+    neutron: [1, 0],
+    proton: [1, 1],
+};
+
 function isValidAtomicNumber(test: Particle | Isotope): boolean {
     if (isIsotope(test)) {
         return chemicalSymbol.indexOf(test.element) + 1 === test.atomic &&
             test.mass > test.atomic;
     }
-    switch(test.particle) {
-        case "alphaparticle":
-            return test.mass === 4 &&
-                test.atomic === 2;
-        case "betaparticle":
-            return test.mass === 0 &&
-                test.atomic === -1;
-        case "gammaray":
-            return test.mass === 0 &&
-                test.atomic === 0;
-        case "neutrino":
-            return test.mass === 0 &&
-                test.atomic === 0;
-        case "antineutrino":
-            return test.mass === 0 &&
-                test.atomic === 0;
-        case "electron":
-            return test.mass === 0 &&
-                test.atomic === -1;
-        case "positron":
-            return test.mass === 0 &&
-                test.atomic === 1;
-        case "neutron":
-            return test.mass === 1 &&
-                test.atomic === 0;
-        case "proton":
-            return test.mass === 1 &&
-                test.atomic === 1;
-    }
+    return particleMassAtomic[test.particle][0] === test.mass && particleMassAtomic[test.particle][1] === test.atomic;
 }
 
 function checkParticlesEqual(test: Particle, target: Particle): boolean {
@@ -172,6 +156,13 @@ function checkParticlesEqual(test: Particle, target: Particle): boolean {
     } else {
         return test.particle === target.particle;
     }
+}
+
+function missingMassAtomicError(response: CheckerResponse): CheckerResponse {
+    response.containsError = true;
+    response.error = "Check that all atoms have a mass and atomic number!";
+    response.isEqual = false;
+    return response;
 }
 
 const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (options) => { return {
@@ -190,9 +181,17 @@ const STARTING_RESPONSE: (options?: ChemistryOptions) => CheckerResponse = (opti
 
 function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerResponse): CheckerResponse {
     if (isParticle(test) && isParticle(target)) {
-        // Answers can be entered without a mass or atomic number. Some particles e.g. electrons can be validly represented this way so a conversion is made
-        if (test.mass === null) test.mass = 0;
-        if (test.atomic === null) test.atomic = 0;
+        // Answers can be entered without a mass or atomic number. Particles with 0 mass e.g. electrons can be validly represented this way so a conversion is made
+        if (test.mass === null && test.atomic === null) {
+            if (particleMassAtomic[test.particle][0] === 0) {
+                test.mass = particleMassAtomic[test.particle][0];
+                test.atomic = particleMassAtomic[test.particle][1];
+            } else {
+                return missingMassAtomicError(response);
+            }
+        } else if (test.mass === null || test.atomic === null) {
+            return missingMassAtomicError(response);
+        }
 
         response.validAtomicNumber = (response.validAtomicNumber ?? true) && isValidAtomicNumber(test);
         response.sameElements = response.sameElements && checkParticlesEqual(test, target);
@@ -210,12 +209,9 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
 
         return response;
     } else if (isIsotope(test) && isIsotope(target)) {
-        // Answers can be entered without a mass or atomic number. However, this is always wrong for isotopes so we throw an error
+        // Answers can be entered without a mass or atomic number. However, this is always wrong for isotopes so we always throw an error
         if (test.mass === null || test.atomic === null) {
-            response.containsError = true;
-            response.error = "Check that all atoms have a mass and atomic number!"
-            response.isEqual = false;
-            return response;
+            return missingMassAtomicError(response);
         }
 
         response.sameElements = response.sameElements && test.element === target.element;


### PR DESCRIPTION
There are two similar but unrelated issues with electron/subatomic particle representation in the chemistry/nuclear checker respectively currently, each breaking certain ways that an answer can be accepted.

- **Chemistry:** Electrons have inherent +1 charge that is not represented as a property. This charge wasn't being counted in `chargeCount`, and so non-exact matching for half-equations was failing. 

- **Nuclear:** Subatomic particles without mass (e.g. electrons, neutrinos, betaparticles) are sometimes allowed in Content as answers without mass/atomic numbers attached (as well as the same answer WITH the numbers attached).  We had been assuming that missing mass/atomic numbers were erroneous, but this has now been disabled for massless particles and instead the values default to correct.