### PR TITLE
Change default charge to 0 from undefined to improve charge equality checking

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -128,6 +128,7 @@ const STARTING_RESPONSE: (options?: ChemistryOptions, coefficientScalingValue?: 
     sameArrow: true,
     sameBrackets: true,
     isChargeBalanced: true,
+    chargeCount: STARTING_COEFFICIENT,
     options: options ?? {},
     coefficientScalingValue: coefficientScalingValue ?? STARTING_COEFFICIENT,
 } };


### PR DESCRIPTION
For questions with equations including one side of the equation using charged particles (where the charge equals 0) and the other not including any (where the charge should also equal 0), the side without charged particles is instead calculated as `undefined`.

To fix this, charge should instead be initialised with the statement’s `result` as `STARTING_COEFFICIENT` (0 as a fraction).