### PR TITLE
Count aggregates in a consistent way when failing a list/linear comparison

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -563,6 +563,13 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         if (finalResponse.sameElements && !finalResponse.isBalanced && !finalResponse.sameCoefficient) {
             finalResponse.isBalanced = true;
         }
+        // If the equation is imbalanced due to an undefined count (e.g. due to a parse error), balance feedback is not useful
+        if (!finalResponse.isBalanced && (leftResponse.atomCount === undefined || rightResponse.atomCount === undefined)) {
+            finalResponse.isBalanced = true;
+        }
+        if (!finalResponse.isChargeBalanced && (leftResponse.chargeCount === undefined || rightResponse.chargeCount === undefined)) {
+            finalResponse.isChargeBalanced = true;
+        }
 
         finalResponse.isEqual = finalResponse.isEqual && finalResponse.sameArrow && finalResponse.isBalanced && finalResponse.isChargeBalanced;
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -84,6 +84,31 @@ export function removeAggregates(response: CheckerResponse): CheckerResponse {
     return response;
 }
 
+function attachAggregates(response: CheckerResponse, aggregatesResponse: CheckerResponse): CheckerResponse {
+    // Attach aggregate values to the response. These are used for feedback, but not for equality checks
+    response.bracketChargeCount = aggregatesResponse.bracketChargeCount;
+    response.termChargeCount = aggregatesResponse.termChargeCount;
+    response.chargeCount = aggregatesResponse.chargeCount;
+    response.bracketAtomCount = aggregatesResponse.bracketAtomCount;
+    response.termAtomCount = aggregatesResponse.termAtomCount;
+    response.atomCount = aggregatesResponse.atomCount;
+    response.termNucleonCount = aggregatesResponse.termNucleonCount;
+    response.nucleonCount = aggregatesResponse.nucleonCount;
+
+    return response;
+}
+
+function attachAggregatesFromList<T>(response: CheckerResponse, itemList: T[], comparator: (test: T, target: T, response: CheckerResponse) => CheckerResponse): CheckerResponse {
+    let aggregatesResponse = structuredClone(response);
+    for (let item of itemList) {
+        // This will always pass, this is to get the accurate aggregate bookkeeping values
+        aggregatesResponse = comparator(item, item, structuredClone(aggregatesResponse));
+    }
+    console.log("ilac", itemList, response.atomCount, aggregatesResponse.atomCount);
+
+    return attachAggregates(response, aggregatesResponse);
+}
+
 export function linearComparison<T>(
     testList: T[],
     targetList: T[],
@@ -95,6 +120,8 @@ export function linearComparison<T>(
     if (testList.length !== targetList.length) {
         possibleResponse.sameElements = false;
         possibleResponse.isEqual = false;
+        possibleResponse = attachAggregatesFromList(possibleResponse, testList, comparator);
+
         return possibleResponse;
     }
 
@@ -113,13 +140,6 @@ export function listComparison<T>(
 ): CheckerResponse {
     const indices: number[] = []; // the indices on which a match was made
     let possibleResponse = structuredClone(response);
-
-    // Get aggregates
-    let aggregatesResponse = structuredClone(response);
-    for (let item of testList) {
-        // This will always pass, this is to get the accurate aggregate bookkeeping values
-        aggregatesResponse = comparator(item, item, aggregatesResponse);
-    }
 
     for (let testItem of testList) {
         let index = 0;
@@ -145,18 +165,9 @@ export function listComparison<T>(
 
         if (failed) {
             // Try to get some new information otherwise use the passed response
-            const returnResponse = currResponse ?? structuredClone(response);
+            let returnResponse = currResponse ?? structuredClone(response);
             returnResponse.isEqual = false;
-
-            // Attach actual aggregate values
-            returnResponse.bracketChargeCount = aggregatesResponse.bracketChargeCount;
-            returnResponse.termChargeCount = aggregatesResponse.termChargeCount;
-            returnResponse.chargeCount = aggregatesResponse.chargeCount;
-            returnResponse.bracketAtomCount = aggregatesResponse.bracketAtomCount;
-            returnResponse.termAtomCount = aggregatesResponse.termAtomCount;
-            returnResponse.atomCount = aggregatesResponse.atomCount;
-            returnResponse.termNucleonCount = aggregatesResponse.termNucleonCount;
-            returnResponse.nucleonCount = aggregatesResponse.nucleonCount;
+            returnResponse = attachAggregatesFromList(returnResponse, testList, comparator);
 
             return returnResponse;
         }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -163,15 +163,12 @@ export function listComparison<T>(
         }
 
         if (failed) {
-            // Any information other than aggregates (e.g. typeMismatch) should be kept from the failed response if possible
-            let returnResponse = currResponse ?? structuredClone(response);
-            returnResponse.isEqual = false;
-
             // Full lists of aggregates are gathered from the initial response, rather than incomplete lists from the failed response
-            const aggregatesResponse = attachAggregatesFromList(response, testList, comparator);
-            returnResponse = attachAggregates(returnResponse, aggregatesResponse);
+            // Non-aggregate results cannot be used conclusively, as their correctness will depend on the specific list permutation
+            const aggregatesResponse = attachAggregatesFromList(possibleResponse, testList, comparator);
+            aggregatesResponse.isEqual = false;
 
-            return returnResponse;
+            return aggregatesResponse;
         }
     }
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -104,7 +104,6 @@ function attachAggregatesFromList<T>(response: CheckerResponse, itemList: T[], c
         // This will always pass, this is to get the accurate aggregate bookkeeping values
         aggregatesResponse = comparator(item, item, structuredClone(aggregatesResponse));
     }
-    console.log("ilac", itemList, response.atomCount, aggregatesResponse.atomCount);
 
     return attachAggregates(response, aggregatesResponse);
 }
@@ -120,7 +119,7 @@ export function linearComparison<T>(
     if (testList.length !== targetList.length) {
         possibleResponse.sameElements = false;
         possibleResponse.isEqual = false;
-        possibleResponse = attachAggregatesFromList(possibleResponse, testList, comparator);
+        possibleResponse = attachAggregatesFromList(response, testList, comparator);
 
         return possibleResponse;
     }
@@ -167,7 +166,7 @@ export function listComparison<T>(
             // Try to get some new information otherwise use the passed response
             let returnResponse = currResponse ?? structuredClone(response);
             returnResponse.isEqual = false;
-            returnResponse = attachAggregatesFromList(returnResponse, testList, comparator);
+            returnResponse = attachAggregatesFromList(response, testList, comparator);
 
             return returnResponse;
         }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -167,7 +167,7 @@ export function listComparison<T>(
             let returnResponse = currResponse ?? structuredClone(response);
             returnResponse.isEqual = false;
 
-            // Full lists of aggregates are gathered from the initial response
+            // Full lists of aggregates are gathered from the initial response, rather than incomplete lists from the failed response
             const aggregatesResponse = attachAggregatesFromList(response, testList, comparator);
             returnResponse = attachAggregates(returnResponse, aggregatesResponse);
 

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -163,10 +163,13 @@ export function listComparison<T>(
         }
 
         if (failed) {
-            // Try to get some new information otherwise use the passed response
+            // Any information other than aggregates (e.g. typeMismatch) should be kept from the failed response if possible
             let returnResponse = currResponse ?? structuredClone(response);
             returnResponse.isEqual = false;
-            returnResponse = attachAggregatesFromList(response, testList, comparator);
+
+            // Full lists of aggregates are gathered from the initial response
+            const aggregatesResponse = attachAggregatesFromList(response, testList, comparator);
+            returnResponse = attachAggregates(returnResponse, aggregatesResponse);
 
             return returnResponse;
         }

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -165,7 +165,7 @@ export function listComparison<T>(
         if (failed) {
             // Full lists of aggregates are gathered from the initial response, rather than incomplete lists from the failed response
             // Non-aggregate results cannot be used conclusively, as their correctness will depend on the specific list permutation
-            const aggregatesResponse = attachAggregatesFromList(possibleResponse, testList, comparator);
+            const aggregatesResponse = attachAggregatesFromList(response, testList, comparator);
             aggregatesResponse.isEqual = false;
 
             return aggregatesResponse;


### PR DESCRIPTION
The chemistry checker is designed to keep an accurate track of the number of atoms/charges(/nucleons in Nuclear) encountered, regardless of other equality checks failing (except in specific instances of failing early, such as with errors in the grammar).

This mostly works, except for certain cases when doing a multi-item comparison:
- Linear comparison, in which each item in one list is compared with the same index item in another. If lists are of different sizes, they definitely aren't equal - however, we weren't checking aggregates when this came up. We now do an aggregate-counting pass (comparing the test list with itself) to include these counts.
- List comparison, in which each item in one list is compared with all items in the other until either a matching combination is found or all permutations are exhausted. 
We were attempting to keep track of some information from these permutations in the final result, however this could be overgenerous with setting flags (e.g. `H2O + I^{+}`  VS  `I^{+} + H3O` would have its final permutation checking `H2O` against `I^{+}` which is a type mismatch, however the answer does not actually contain type errors).
The only information we can safely gather is aggregate counts, and this is moved after the failure flag to save processing time on successful lists.

Since both of these comparisons now use an aggregate-counting pass, this logic is separated into some helper functions.

Also to avoid future problems, adds a check for undefined atoms/charge and unsets the `isBalanced`/`isChargeBalanced` flags for this case so we don't give spurious warnings.