### PR TITLE
Count hydrate in atomCount (as well as existing direct check)

### DIFF
--- a/src/models/Chemistry.ts
+++ b/src/models/Chemistry.ts
@@ -503,6 +503,15 @@ function checkNodesEqual(test: ASTNode, target: ASTNode, response: CheckerRespon
         newResponse.sameState = newResponse.sameState && test.state === target.state;
         newResponse.sameHydrate = newResponse.sameHydrate && test.isHydrate === target.isHydrate && test.hydrate === target.hydrate;
 
+        // If the term contains a hydrate, add the H2 and O from the hydrate to the termAtomCount
+        if (test.isHydrate) {
+            if (!newResponse.termAtomCount) {
+                newResponse.termAtomCount = {} as Record<ChemicalSymbol, number | undefined>;
+            }
+            newResponse.termAtomCount["H"] = (newResponse.termAtomCount["H"] ?? 0) + test.hydrate * 2;
+            newResponse.termAtomCount["O"] = (newResponse.termAtomCount["O"] ?? 0) + test.hydrate;
+        }
+
         // Add the term's atomCount (* coefficient) to the overall expression atomCount
         if (newResponse.termAtomCount) {
             for (const [key, value] of Object.entries(newResponse.termAtomCount)) {

--- a/src/test/models/Chemistry.test.ts
+++ b/src/test/models/Chemistry.test.ts
@@ -106,9 +106,6 @@ const statement: Statement = {
     right: structuredClone(expression),
     arrow: "SArr"
 }
-if ("rest" in statement.right && statement.right.rest && "hydrate" in statement.right.rest) {
-    statement.right.rest.hydrate = 1;
-}
 const augmentedStatement: Statement = augmentNode(structuredClone(statement));
 
 const ast: ChemAST = {
@@ -602,7 +599,7 @@ describe("testCheck Expression", () => {
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
-            expect(testResponse.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
+            expect(testResponse.atomCount?.O).toEqual({"numerator": 18, "denominator": 1});
         }
     );
     it("Returns truthy CheckerResponse when expressions match with allowScalingCoefficients", 
@@ -621,7 +618,7 @@ describe("testCheck Expression", () => {
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
-            expect(testResponse.atomCount?.O).toEqual({"numerator": 4, "denominator": 1});
+            expect(testResponse.atomCount?.O).toEqual({"numerator": 24, "denominator": 1});
         }
     );
     it("Returns falsy CheckerResponse when expressions have mismatched terms",
@@ -729,13 +726,18 @@ describe("testCheck Statement", () => {
 
             // Assert
             expect(testResponse.isEqual).toBeTruthy();
-            expect(testResponse.atomCount?.O).toEqual({"numerator": 2, "denominator": 3});
+            expect(testResponse.atomCount?.O).toEqual({"numerator": 4, "denominator": 1});
         }
     );
     it("Returns falsy CheckerResponse when expressions don't match",
         () => {
             // Arrange
-            const swappedExpressions: Statement = structuredClone(statement);
+            const unbalancedStatement: Statement = structuredClone(statement);
+            if ("rest" in unbalancedStatement.right && unbalancedStatement.right.rest && "hydrate" in unbalancedStatement.right.rest) {
+                unbalancedStatement.right.rest.hydrate = 1;
+            }
+            
+            const swappedExpressions: Statement = structuredClone(unbalancedStatement);
             const tempExpression = swappedExpressions.left;
             swappedExpressions.left = swappedExpressions.right;
             swappedExpressions.right = tempExpression;
@@ -762,7 +764,7 @@ describe("testCheck Statement", () => {
             // Asssert
             expect(balancedCheck.isEqual).toBeTruthy();
             expect(balancedCheck.isBalanced).toBeTruthy();
-            expect(balancedCheck.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
+            expect(balancedCheck.atomCount?.O).toEqual({"numerator": 18, "denominator": 1});
         }
     );
     it("Returns falsy CheckerResponse when statements are unbalanced", 
@@ -778,7 +780,7 @@ describe("testCheck Statement", () => {
             // Asssert
             expect(unbalancedCheck.isEqual).toBeFalsy();
             expect(unbalancedCheck.isBalanced).toBeFalsy();
-            expect(unbalancedCheck.atomCount?.O).toEqual({"numerator": 3, "denominator": 1});
+            expect(unbalancedCheck.atomCount?.O).toEqual({"numerator": 18, "denominator": 1});
         }
     );
     it("Returns truthy CheckerResponse when statements charges are balanced", 


### PR DESCRIPTION
The water of crystallisation/hydrate at the end of a term is being checked for presence, but not being counted towards the atoms in that term. It should be counted (as a number of H2Os).

It looks like this arose from the switchover in main developer of the checker, since at that time there was only a rudimentary version of atomCount which had included all base counts _except_ hydrates.

(High numbers of hydrates are used in tests, so the numbers are changing quite wildly in that file :])